### PR TITLE
Feature/project overview user interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Introduce a View showing all ProjectCodes and ProjectTitles for a user (`#27 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/27>`_)
+
 * Provide the authentication provider id with the user information
 
 * Add a mechanism for in app communication between components (`#23 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/23>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
-* Introduce a View showing all ProjectCodes and ProjectTitles for a user (`#27 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/27>`_)
+* Introduce a grid showing all project codes and titles for a user (`#27 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/27>`_)
 
 * Provide the authentication provider id with the user information
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -3,6 +3,7 @@ package life.qbic.portal.sampletracking
 import com.vaadin.ui.VerticalLayout
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewView
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
+import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 
 /**
  * <h1>Class that manages all the dependency injections and class instance creations</h1>
@@ -17,9 +18,16 @@ import life.qbic.portal.sampletracking.components.projectoverview.ProjectOvervie
 class DependencyManager {
     VerticalLayout portletView
 
+    private ProjectResourceService projectResourceService
+
     DependencyManager() {
-        ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel()
+        setupServices()
+        ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel(projectResourceService)
         portletView = new ProjectOverviewView(viewModel)
+    }
+
+    private void setupServices() {
+        this.projectResourceService = new ProjectResourceService()
     }
 
     VerticalLayout getPortletView() {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -2,6 +2,9 @@ package life.qbic.portal.sampletracking
 
 import com.vaadin.ui.VerticalLayout
 import life.qbic.datamodel.dtos.projectmanagement.Project
+import life.qbic.datamodel.dtos.projectmanagement.ProjectCode
+import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
+import life.qbic.datamodel.dtos.projectmanagement.ProjectSpace
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewView
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
 import life.qbic.portal.sampletracking.resource.ResourceService
@@ -25,6 +28,9 @@ class DependencyManager {
     DependencyManager() {
         initializeDependencies()
         portletView = setupPortletView()
+
+        //FIXME remove demo material
+        demo()
     }
 
     private void initializeDependencies() {
@@ -54,5 +60,16 @@ class DependencyManager {
     private createProjectOverviewView() {
         ProjectOverviewViewModel projectOverviewViewModel = new ProjectOverviewViewModel(projectResourceService)
         return new ProjectOverviewView(projectOverviewViewModel)
+    }
+
+    //FIXME remove
+    private void demo() {
+        Project project1 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 1"), new ProjectCode("QABCD")), "My Awesome Project1").build()
+        Project project2 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 2"), new ProjectCode("QABCE")), "My Awesome Project2").build()
+        Project project3 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 3"), new ProjectCode("QABCF")), "My Awesome Project3").build()
+
+        projectResourceService.addToResource(project1)
+        projectResourceService.addToResource(project2)
+        projectResourceService.addToResource(project3)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -22,8 +22,7 @@ class DependencyManager {
 
     DependencyManager() {
         setupServices()
-        ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel(projectResourceService)
-        portletView = new ProjectOverviewView(viewModel)
+        portletView = setupPortletView()
     }
 
     private void setupServices() {
@@ -32,5 +31,23 @@ class DependencyManager {
 
     VerticalLayout getPortletView() {
         return portletView
+    }
+
+    private VerticalLayout setupPortletView() {
+        ProjectOverviewView projectOverviewView = createProjectOverviewView()
+        return projectOverviewView
+    }
+
+    /**
+     * Creates a new ProjectOverviewView using
+     * <ul>
+     *     <li>{@link #projectResourceService}</li>
+     * </ul>
+     * @return a new ProjectOverviewView
+     */
+    private createProjectOverviewView() {
+        ProjectResourceService projectResourceService = this.projectResourceService
+        ProjectOverviewViewModel projectOverviewViewModel = new ProjectOverviewViewModel(projectResourceService)
+        return new ProjectOverviewView(projectOverviewViewModel)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -1,8 +1,10 @@
 package life.qbic.portal.sampletracking
 
 import com.vaadin.ui.VerticalLayout
+import life.qbic.datamodel.dtos.projectmanagement.Project
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewView
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
+import life.qbic.portal.sampletracking.resource.ResourceService
 import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 
 /**
@@ -18,15 +20,19 @@ import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 class DependencyManager {
     VerticalLayout portletView
 
-    private ProjectResourceService projectResourceService
+    ResourceService<Project> projectResourceService
 
     DependencyManager() {
-        setupServices()
+        initializeDependencies()
         portletView = setupPortletView()
     }
 
+    private void initializeDependencies() {
+        setupServices()
+    }
+
     private void setupServices() {
-        this.projectResourceService = new ProjectResourceService()
+        projectResourceService = new ProjectResourceService()
     }
 
     VerticalLayout getPortletView() {
@@ -46,7 +52,6 @@ class DependencyManager {
      * @return a new ProjectOverviewView
      */
     private createProjectOverviewView() {
-        ProjectResourceService projectResourceService = this.projectResourceService
         ProjectOverviewViewModel projectOverviewViewModel = new ProjectOverviewViewModel(projectResourceService)
         return new ProjectOverviewView(projectOverviewViewModel)
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/StatusOverviewApp.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/StatusOverviewApp.groovy
@@ -9,8 +9,6 @@ import com.vaadin.ui.VerticalLayout
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j2
 import life.qbic.portal.sampletracking.components.StyledNotification
-import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewView
-import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
 
 
 /**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/GridUtils.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/GridUtils.groovy
@@ -6,5 +6,5 @@ package life.qbic.portal.sampletracking.components
  * @since 1.0.0
  */
 class GridUtils {
-    final static int DESCRIPTION_COLUMN_LIMIT = 400
+    final static int TITLE_COLUMN_WIDTH = 400
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -1,16 +1,10 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
 import com.vaadin.data.provider.ListDataProvider
-import com.vaadin.icons.VaadinIcons
-import com.vaadin.shared.data.sort.SortDirection
 import com.vaadin.shared.ui.grid.HeightMode
 import com.vaadin.ui.*
-import com.vaadin.ui.renderers.DateRenderer
-import com.vaadin.ui.renderers.ProgressBarRenderer
 import com.vaadin.ui.themes.ValoTheme
-import life.qbic.business.projectoverview.FailedSamplesRatio
-import life.qbic.business.projectoverview.Project
-import life.qbic.portal.sampletracking.components.GridUtils
+import life.qbic.datamodel.dtos.projectmanagement.Project
 
 /**
  * <h1>This class generates the layout for the ProductOverview use case</h1>
@@ -25,7 +19,6 @@ class ProjectOverviewView extends VerticalLayout{
 
     private Label titleLabel
     private ProjectOverviewViewModel viewModel
-
     private Grid<Project> projectGrid
 
     ProjectOverviewView(ProjectOverviewViewModel viewModel){
@@ -44,7 +37,7 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void fillGrid(){
-        projectGrid.addColumn({ it.projectCode })
+        projectGrid.addColumn({ it.projectId.projectCode.code})
                 .setCaption("Project Code").setId("ProjectCode")
         projectGrid.addColumn({ it.projectTitle })
                 .setCaption("Project Title").setId("ProjectTitle")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -27,8 +27,6 @@ class ProjectOverviewView extends VerticalLayout{
     private ProjectOverviewViewModel viewModel
 
     private Grid<Project> projectGrid
-    private Button detailsButton
-    private Button downloadButton
 
     ProjectOverviewView(ProjectOverviewViewModel viewModel){
         this.viewModel = viewModel
@@ -42,39 +40,20 @@ class ProjectOverviewView extends VerticalLayout{
         titleLabel.addStyleName(ValoTheme.LABEL_LARGE)
         projectGrid = new Grid<>()
 
-        detailsButton = new Button("Show Details",VaadinIcons.INFO_CIRCLE_O)
-        detailsButton.addStyleName(ValoTheme.LABEL_LARGE)
-        detailsButton.enabled = false
-        downloadButton = new Button("Download Batch Data",VaadinIcons.DOWNLOAD)
-        downloadButton.addStyleName(ValoTheme.LABEL_LARGE)
-        downloadButton.enabled = false
-
-        HorizontalLayout buttonLayout = new HorizontalLayout(detailsButton,downloadButton)
-
-        this.addComponents(titleLabel,buttonLayout,projectGrid)
+        this.addComponents(titleLabel, projectGrid)
     }
 
     private void fillGrid(){
         projectGrid.addColumn({ it.projectCode })
                 .setCaption("Project Code").setId("ProjectCode")
-        projectGrid.addColumn({it.projectProgress}).setRenderer(progress -> progress, new ProgressBarRenderer())
-        Grid.Column<Project, FailedSamplesRatio> failedSamplesColumn = projectGrid.addColumn({ it.failedSamples })
-                .setCaption("Failed Samples").setId("FailedSamples")
-        //failedSamplesColumn.setRenderer(failedSamples -> failedSamples, new TextRenderer())
-        Grid.Column<Project,Date> lastUpdatedColumn = projectGrid.addColumn({ it.lastUpdate })
-                .setCaption("Last Update").setId("LastUpdate")
-        lastUpdatedColumn.setRenderer(date -> date, new DateRenderer('%1$tY-%1$tm-%1$td'))
-        Grid.Column<Project,String> descriptionColumn = projectGrid.addColumn({ it.projectDescription })
-                .setCaption("Description").setId("Description").setDescriptionGenerator({it.projectDescription})
+        projectGrid.addColumn({ it.projectTitle })
+                .setCaption("Project Title").setId("ProjectTitle")
 
         setupDataProvider()
-
         //specify size of grid and layout
         projectGrid.setWidthFull()
         //todo introduce variable for description column width
-        descriptionColumn.setWidth(GridUtils.DESCRIPTION_COLUMN_LIMIT)
         projectGrid.setHeightMode(HeightMode.ROW)
-        projectGrid.sort("LastUpdate", SortDirection.ASCENDING)
     }
 
     private void setupDataProvider() {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -41,7 +41,7 @@ class ProjectOverviewView extends VerticalLayout{
         projectGrid.addColumn({ it.projectId.projectCode.code})
                 .setCaption("Project Code").setId("ProjectCode")
         projectGrid.addColumn({ it.projectTitle })
-                .setCaption("Project Title").setId("ProjectTitle").setWidth(GridUtils.DESCRIPTION_COLUMN_LIMIT)
+                .setCaption("Project Title").setId("ProjectTitle").setWidth(GridUtils.TITLE_COLUMN_WIDTH)
         setupDataProvider()
         //specify size of grid and layout
         projectGrid.setWidthFull()

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -5,6 +5,7 @@ import com.vaadin.shared.ui.grid.HeightMode
 import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
 import life.qbic.datamodel.dtos.projectmanagement.Project
+import life.qbic.portal.sampletracking.components.GridUtils
 
 /**
  * <h1>This class generates the layout for the ProductOverview use case</h1>
@@ -40,8 +41,7 @@ class ProjectOverviewView extends VerticalLayout{
         projectGrid.addColumn({ it.projectId.projectCode.code})
                 .setCaption("Project Code").setId("ProjectCode")
         projectGrid.addColumn({ it.projectTitle })
-                .setCaption("Project Title").setId("ProjectTitle")
-
+                .setCaption("Project Title").setId("ProjectTitle").setWidth(GridUtils.DESCRIPTION_COLUMN_LIMIT)
         setupDataProvider()
         //specify size of grid and layout
         projectGrid.setWidthFull()

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -1,9 +1,9 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
-import life.qbic.business.projectoverview.Project
+import life.qbic.datamodel.dtos.projectmanagement.Project
 import life.qbic.portal.sampletracking.communication.Subscriber
 import life.qbic.portal.sampletracking.communication.Topic
-import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
+import life.qbic.portal.sampletracking.resource.ResourceService
 
 /**
  * <h1>ViewModel for the {@link ProjectOverviewView}</h1>
@@ -16,12 +16,12 @@ import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 class ProjectOverviewViewModel {
 
     ObservableList projects = new ArrayList<Project>()
-    final ProjectResourceService projectResourceService
+    private final ResourceService<Project> projectResourceService
 
     Subscriber<Project> projectAddedSubscription
     Subscriber<Project> projectRemovedSubscription
 
-    ProjectOverviewViewModel(ProjectResourceService projectResourceService){
+    ProjectOverviewViewModel(ResourceService<Project> projectResourceService){
         this.projectResourceService = projectResourceService
         fetchProjectData()
         subscribeToResources()

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -1,10 +1,6 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
 import life.qbic.business.projectoverview.Project
-import life.qbic.datamodel.dtos.business.services.Product
-import life.qbic.datamodel.dtos.general.Person
-import life.qbic.datamodel.samples.Location
-import life.qbic.datamodel.samples.Sample
 import life.qbic.portal.sampletracking.communication.Subscriber
 import life.qbic.portal.sampletracking.communication.Topic
 import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
@@ -19,7 +15,7 @@ import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 */
 class ProjectOverviewViewModel {
 
-    ObservableList projects = new ObservableList(new ArrayList<Project>())
+    ObservableList projects = new ArrayList<Project>()
     final ProjectResourceService projectResourceService
 
     Subscriber<life.qbic.datamodel.dtos.projectmanagement.Project> projectAddedSubscription
@@ -29,8 +25,6 @@ class ProjectOverviewViewModel {
         this.projectResourceService = projectResourceService
         fetchProjectData()
         subscribeToResources()
-        //Todo Remove Mock data when project data is in service
-        generateMockData()
     }
 
     private void fetchProjectData() {
@@ -41,20 +35,5 @@ class ProjectOverviewViewModel {
     private void subscribeToResources() {
         this.projectResourceService.subscribe(projectAddedSubscription, Topic.PROJECT_ADDED)
         this.projectResourceService.subscribe(projectRemovedSubscription, Topic.PROJECT_REMOVED)
-        //ToDo How to trigger fetchProjectData here?
-    }
-    //Todo Remove Mock data generation when project resource service provides list of projects
-    void generateMockData(){
-        Location location = new Location()
-
-        Sample sample = new Sample()
-        sample.setCode("Q1234AC")
-        sample.setCurrentLocation(location)
-
-        Project project1 = new Project.Builder("Q1234","This is a test project","Project Title 1",[sample]).progress(0).build()
-        Project project2 = new Project.Builder("Q1244","This is a test project 2","Project Title 2",[sample]).progress(1).build()
-        Project project3 = new Project.Builder("Q1233","This is a test project 3","Project Title 3",[sample]).progress(0.9).failedSamples(1).build()
-
-        projects.addAll(project1,project2,project3)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -1,8 +1,13 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
 import life.qbic.business.projectoverview.Project
+import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.datamodel.dtos.general.Person
 import life.qbic.datamodel.samples.Location
 import life.qbic.datamodel.samples.Sample
+import life.qbic.portal.sampletracking.communication.Subscriber
+import life.qbic.portal.sampletracking.communication.Topic
+import life.qbic.portal.sampletracking.resource.project.ProjectResourceService
 
 /**
  * <h1>ViewModel for the {@link ProjectOverviewView}</h1>
@@ -14,12 +19,31 @@ import life.qbic.datamodel.samples.Sample
 */
 class ProjectOverviewViewModel {
 
-    List<Project> projects = []
+    ObservableList projects = new ObservableList(new ArrayList<Project>())
+    final ProjectResourceService projectResourceService
 
-    ProjectOverviewViewModel(){
+    Subscriber<life.qbic.datamodel.dtos.projectmanagement.Project> projectAddedSubscription
+    Subscriber<life.qbic.datamodel.dtos.projectmanagement.Project> projectRemovedSubscription
+
+    ProjectOverviewViewModel(ProjectResourceService projectResourceService){
+        this.projectResourceService = projectResourceService
+        fetchProjectData()
+        subscribeToResources()
+        //Todo Remove Mock data when project data is in service
         generateMockData()
     }
 
+    private void fetchProjectData() {
+        projects.clear()
+        projects.addAll(projectResourceService.iterator())
+    }
+
+    private void subscribeToResources() {
+        this.projectResourceService.subscribe(projectAddedSubscription, Topic.PROJECT_ADDED)
+        this.projectResourceService.subscribe(projectRemovedSubscription, Topic.PROJECT_REMOVED)
+        //ToDo How to trigger fetchProjectData here?
+    }
+    //Todo Remove Mock data generation when project resource service provides list of projects
     void generateMockData(){
         Location location = new Location()
 
@@ -27,9 +51,9 @@ class ProjectOverviewViewModel {
         sample.setCode("Q1234AC")
         sample.setCurrentLocation(location)
 
-        Project project1 = new Project.Builder("Q1234","This is a test project",[sample]).progress(0).build()
-        Project project2 = new Project.Builder("Q1244","This is a test project 2",[sample]).progress(1).build()
-        Project project3 = new Project.Builder("Q1233","This is a test project 3",[sample]).progress(0.9).failedSamples(1).build()
+        Project project1 = new Project.Builder("Q1234","This is a test project","Project Title 1",[sample]).progress(0).build()
+        Project project2 = new Project.Builder("Q1244","This is a test project 2","Project Title 2",[sample]).progress(1).build()
+        Project project3 = new Project.Builder("Q1233","This is a test project 3","Project Title 3",[sample]).progress(0.9).failedSamples(1).build()
 
         projects.addAll(project1,project2,project3)
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -18,9 +18,6 @@ class ProjectOverviewViewModel {
     ObservableList projects = new ArrayList<Project>()
     private final ResourceService<Project> projectResourceService
 
-    Subscriber<Project> projectAddedSubscription
-    Subscriber<Project> projectRemovedSubscription
-
     ProjectOverviewViewModel(ResourceService<Project> projectResourceService){
         this.projectResourceService = projectResourceService
         fetchProjectData()
@@ -33,7 +30,7 @@ class ProjectOverviewViewModel {
     }
 
     private void subscribeToResources() {
-        this.projectResourceService.subscribe(projectAddedSubscription, Topic.PROJECT_ADDED)
-        this.projectResourceService.subscribe(projectRemovedSubscription, Topic.PROJECT_REMOVED)
+        this.projectResourceService.subscribe({ projects.add(it) }, Topic.PROJECT_ADDED)
+        this.projectResourceService.subscribe({ projects.remove(it) }, Topic.PROJECT_REMOVED)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -18,8 +18,8 @@ class ProjectOverviewViewModel {
     ObservableList projects = new ArrayList<Project>()
     final ProjectResourceService projectResourceService
 
-    Subscriber<life.qbic.datamodel.dtos.projectmanagement.Project> projectAddedSubscription
-    Subscriber<life.qbic.datamodel.dtos.projectmanagement.Project> projectRemovedSubscription
+    Subscriber<Project> projectAddedSubscription
+    Subscriber<Project> projectRemovedSubscription
 
     ProjectOverviewViewModel(ProjectResourceService projectResourceService){
         this.projectResourceService = projectResourceService

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
@@ -14,12 +14,10 @@ import life.qbic.portal.sampletracking.resource.ResourceService
  */
 class ProjectResourceService extends ResourceService<Project> {
 
-    private final List<Project> projects
 
     ProjectResourceService() {
         addTopic(Topic.PROJECT_ADDED)
         addTopic(Topic.PROJECT_REMOVED)
-        this.projects = new ArrayList<Project>()
         generateMockData()
     }
 
@@ -50,11 +48,9 @@ class ProjectResourceService extends ResourceService<Project> {
         Project project1 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 1"), new ProjectCode("QABCD")), "My Awesome Project1").build()
         Project project2 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 2"), new ProjectCode("QABCE")), "My Awesome Project2").build()
         Project project3 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 3"), new ProjectCode("QABCF")), "My Awesome Project3").build()
-        projects.addAll(project1,project2,project3)
+        ArrayList<Project> projectList = new ArrayList<>()
+        projectList.addAll(project1, project2, project3)
+        content.addAll(projectList)
     }
 
-    @Override
-    Iterator<Project> iterator() {
-        return new ArrayList(projects).iterator()
-    }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
@@ -4,8 +4,6 @@ import life.qbic.datamodel.dtos.projectmanagement.Project
 import life.qbic.datamodel.dtos.projectmanagement.ProjectCode
 import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
 import life.qbic.datamodel.dtos.projectmanagement.ProjectSpace
-import life.qbic.datamodel.samples.Location
-import life.qbic.datamodel.samples.Sample
 import life.qbic.portal.sampletracking.communication.Topic
 import life.qbic.portal.sampletracking.resource.ResourceService
 
@@ -48,11 +46,6 @@ class ProjectResourceService extends ResourceService<Project> {
     }
 
     void generateMockData(){
-        Location location = new Location()
-
-        Sample sample = new Sample()
-        sample.setCode("Q1234AC")
-        sample.setCurrentLocation(location)
 
         Project project1 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 1"), new ProjectCode("QABCD")), "My Awesome Project1").build()
         Project project2 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 2"), new ProjectCode("QABCE")), "My Awesome Project2").build()

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
@@ -1,6 +1,11 @@
 package life.qbic.portal.sampletracking.resource.project
 
 import life.qbic.datamodel.dtos.projectmanagement.Project
+import life.qbic.datamodel.dtos.projectmanagement.ProjectCode
+import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
+import life.qbic.datamodel.dtos.projectmanagement.ProjectSpace
+import life.qbic.datamodel.samples.Location
+import life.qbic.datamodel.samples.Sample
 import life.qbic.portal.sampletracking.communication.Topic
 import life.qbic.portal.sampletracking.resource.ResourceService
 
@@ -11,9 +16,13 @@ import life.qbic.portal.sampletracking.resource.ResourceService
  */
 class ProjectResourceService extends ResourceService<Project> {
 
+    private final List<Project> projects
+
     ProjectResourceService() {
         addTopic(Topic.PROJECT_ADDED)
         addTopic(Topic.PROJECT_REMOVED)
+        this.projects = new ArrayList<Project>()
+        generateMockData()
     }
 
     /**
@@ -36,5 +45,23 @@ class ProjectResourceService extends ResourceService<Project> {
     @Override
     void removeFromResource(Project resourceItem) {
         publish(resourceItem, Topic.PROJECT_REMOVED)
+    }
+
+    void generateMockData(){
+        Location location = new Location()
+
+        Sample sample = new Sample()
+        sample.setCode("Q1234AC")
+        sample.setCurrentLocation(location)
+
+        Project project1 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 1"), new ProjectCode("QABCD")), "My Awesome Project1").build()
+        Project project2 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 2"), new ProjectCode("QABCE")), "My Awesome Project2").build()
+        Project project3 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 3"), new ProjectCode("QABCF")), "My Awesome Project3").build()
+        projects.addAll(project1,project2,project3)
+    }
+
+    @Override
+    Iterator<Project> iterator() {
+        return new ArrayList(projects).iterator()
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/project/ProjectResourceService.groovy
@@ -18,7 +18,6 @@ class ProjectResourceService extends ResourceService<Project> {
     ProjectResourceService() {
         addTopic(Topic.PROJECT_ADDED)
         addTopic(Topic.PROJECT_REMOVED)
-        generateMockData()
     }
 
     /**
@@ -41,16 +40,6 @@ class ProjectResourceService extends ResourceService<Project> {
     @Override
     void removeFromResource(Project resourceItem) {
         publish(resourceItem, Topic.PROJECT_REMOVED)
-    }
-
-    void generateMockData(){
-
-        Project project1 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 1"), new ProjectCode("QABCD")), "My Awesome Project1").build()
-        Project project2 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 2"), new ProjectCode("QABCE")), "My Awesome Project2").build()
-        Project project3 = new Project.Builder(new ProjectIdentifier(new ProjectSpace("My Awesome ProjectSpace 3"), new ProjectCode("QABCF")), "My Awesome Project3").build()
-        ArrayList<Project> projectList = new ArrayList<>()
-        projectList.addAll(project1, project2, project3)
-        content.addAll(projectList)
     }
 
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/projectoverview/Project.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/projectoverview/Project.groovy
@@ -15,7 +15,6 @@ class Project {
 
     final String projectCode
     final String projectDescription
-    final String projectTitle
     final List<Sample> samples
     double projectProgress
     FailedSamplesRatio failedSamples
@@ -24,17 +23,15 @@ class Project {
     static class Builder {
         private final String projectCode
         private final String projectDescription
-        private final String projectTitle
         private final List<Sample> samples
         private double progress = 0
         private FailedSamplesRatio failedSamples
         private Date lastUpdate = new Date()
 
-        Builder(String projectCode, String projectDescription, String projectTitle, List<Sample> samples) {
+        Builder(String projectCode, String projectDescription, List<Sample> samples) {
             //todo verify the projectCode??
             this.projectCode = projectCode
             this.projectDescription = projectDescription
-            this.projectTitle = projectTitle
             this.samples = samples
 
             failedSamples = new FailedSamplesRatio(0,samples.size())
@@ -59,7 +56,6 @@ class Project {
     private Project(Builder builder) {
         projectCode = builder.projectCode
         projectDescription = builder.projectDescription
-        projectTitle = builder.projectTitle
         samples = builder.samples
         projectProgress = builder.progress
         failedSamples = builder.failedSamples

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/projectoverview/Project.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/projectoverview/Project.groovy
@@ -15,6 +15,7 @@ class Project {
 
     final String projectCode
     final String projectDescription
+    final String projectTitle
     final List<Sample> samples
     double projectProgress
     FailedSamplesRatio failedSamples
@@ -23,15 +24,17 @@ class Project {
     static class Builder {
         private final String projectCode
         private final String projectDescription
+        private final String projectTitle
         private final List<Sample> samples
         private double progress = 0
         private FailedSamplesRatio failedSamples
         private Date lastUpdate = new Date()
 
-        Builder(String projectCode, String projectDescription, List<Sample> samples) {
+        Builder(String projectCode, String projectDescription, String projectTitle, List<Sample> samples) {
             //todo verify the projectCode??
             this.projectCode = projectCode
             this.projectDescription = projectDescription
+            this.projectTitle = projectTitle
             this.samples = samples
 
             failedSamples = new FailedSamplesRatio(0,samples.size())
@@ -56,6 +59,7 @@ class Project {
     private Project(Builder builder) {
         projectCode = builder.projectCode
         projectDescription = builder.projectDescription
+        projectTitle = builder.projectTitle
         samples = builder.samples
         projectProgress = builder.progress
         failedSamples = builder.failedSamples


### PR DESCRIPTION
**Description of changes**
This PR addresses E01.05 by introducing an overview showing a list with ProjectCodes and ProjectTitles. 

**Technical details**
Currently there is no connection to the database, which is necessary to enable the `ProjectResourceService` to provide the projectList. Therefore the project data has to be mocked to showcase the View. 

**Additional context**
We already had a `projectOverviewView` based on wireframes. 
However, @jenniferboedker and I agreed to go back to the drawing board and built the `projectOverviewView` from the ground up with only the necessary information(ProjectCode and ProjectTitle ) provided via `life.qbic.datamodel.dtos.projectmanagement.Project` 
This PR is a draft since it contains mockdata. As soon as that is replaceable this PR will advance. 
