### PR TITLE
add use case

### DIFF
--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -39,9 +39,7 @@ class GetSamplesInfo implements GetSamplesInfoInput {
   void requestSampleInfosFor(String projectCode, Status status) {
     try {
         def sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode, status)
-        println "first succeeded"
         def sampleCodesToNames = infoDataSource.fetchSampleNamesFor(sampleCodes)
-        println "second succeeded"
         
       output.samplesWithNames(projectCode, status, sampleCodesToNames)
     } catch (DataSourceException dataSourceException) {

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -1,0 +1,52 @@
+package life.qbic.business.samples.info
+
+import life.qbic.business.DataSourceException
+import life.qbic.business.samples.download.DownloadSamplesDataSource
+import life.qbic.datamodel.samples.Status
+
+/**
+ * <b>Download samples</b>
+ *
+ * <p>This use case returns samples of a project that have available data attached.</p>
+ *
+ * @since 1.0.0
+ */
+class GetSamplesInfo implements GetSamplesInfoInput {
+  
+  private final DownloadSamplesDataSource samplesDataSource
+  private final GetSamplesInfoDataSource infoDataSource
+  private final GetSamplesInfoOutput output
+
+  /**
+   * Default constructor for this use case
+   * @param dataSource the data source to be used
+   * @param output the output to where results are published
+   * @since 1.0.0
+   */
+  GetSamplesInfo(DownloadSamplesDataSource samplesDataSource, GetSamplesInfoDataSource infoDataSource, GetSamplesInfoOutput output) {
+    this.samplesDataSource = samplesDataSource
+    this.infoDataSource = infoDataSource
+    this.output = output
+  }
+
+  /**
+   * This method calls the output interface with the codes of the samples in a project that have data attached.
+   * In case of failure the output interface failure method is called.
+   * @since 1.0.0
+   */
+  @Override
+  void requestSampleInfosFor(String projectCode, Status status) {
+    try {
+        def sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode, status)
+        println "first succeeded"
+        def sampleCodesToNames = infoDataSource.fetchSampleNamesFor(sampleCodes)
+        println "second succeeded"
+        
+      output.samplesWithNames(projectCode, status, sampleCodesToNames)
+    } catch (DataSourceException dataSourceException) {
+      output.failedExecution(dataSourceException.getMessage())
+    } catch (Exception e) {
+      output.failedExecution("Could not fetch sample codes with available data.")
+    }
+  }
+}

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -5,9 +5,9 @@ import life.qbic.business.samples.download.DownloadSamplesDataSource
 import life.qbic.datamodel.samples.Status
 
 /**
- * <b>Download samples</b>
+ * <b>Get information of samples</b>
  *
- * <p>This use case returns samples of a project that have available data attached.</p>
+ * <p>This use case returns codes and respective names of samples with a requested status of a project.</p>
  *
  * @since 1.0.0
  */
@@ -19,7 +19,8 @@ class GetSamplesInfo implements GetSamplesInfoInput {
 
   /**
    * Default constructor for this use case
-   * @param dataSource the data source to be used
+   * @param samplesDataSource the data source used to fetch sample codes with a certain status
+   * @param infoDataSource the data source used to add metadata (e.g. name) to those sample codes
    * @param output the output to where results are published
    * @since 1.0.0
    */
@@ -30,7 +31,7 @@ class GetSamplesInfo implements GetSamplesInfoInput {
   }
 
   /**
-   * This method calls the output interface with the codes of the samples in a project that have data attached.
+   * This method calls the output interface with the codes and names of the samples in a project that have a provided status.
    * In case of failure the output interface failure method is called.
    * @since 1.0.0
    */

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -44,8 +44,6 @@ class GetSamplesInfo implements GetSamplesInfoInput {
       output.samplesWithNames(projectCode, status, sampleCodesToNames)
     } catch (DataSourceException dataSourceException) {
       output.failedExecution(dataSourceException.getMessage())
-    } catch (Exception e) {
-      output.failedExecution("Could not fetch sample codes with available data.")
-    }
+    } 
   }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoDataSource.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoDataSource.groovy
@@ -2,5 +2,6 @@ package life.qbic.business.samples.info
 
 interface GetSamplesInfoDataSource {
 
+  //used for testing here, description in other PR
     Map<String, String> fetchSampleNamesFor(sampleCodes)
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoDataSource.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoDataSource.groovy
@@ -1,0 +1,6 @@
+package life.qbic.business.samples.info
+
+interface GetSamplesInfoDataSource {
+
+    Map<String, String> fetchSampleNamesFor(sampleCodes)
+}

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
@@ -1,0 +1,24 @@
+package life.qbic.business.samples.info
+
+import life.qbic.datamodel.samples.Status
+
+/**
+ * <b>Input interface for the {@link DownloadSamples} feature</b>
+ *
+ * <p>Provides methods to trigger the fetching of sample codes with available data for one project</p>>
+ *
+ * @since 1.0.0
+ */
+interface GetSamplesInfoInput {
+
+    /**
+     * This method calls the output interface with the codes of samples in the project
+     * that have available data attached
+     * In case of failure the output interface failure method is called.
+     *
+     * @param projectCode a code specifying the samples that should be considered
+     * @since 1.0.0
+     */
+    void requestSampleInfosFor(String projectCode, Status status)
+
+}

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
@@ -3,20 +3,21 @@ package life.qbic.business.samples.info
 import life.qbic.datamodel.samples.Status
 
 /**
- * <b>Input interface for the {@link DownloadSamples} feature</b>
+ * <b>Input interface for the {@link GetSamplesInfo} feature</b>
  *
- * <p>Provides methods to trigger the fetching of sample codes with available data for one project</p>>
+ * <p>Provides methods to trigger the fetching of sample codes and names of samples with provided status for one project</p>>
  *
  * @since 1.0.0
  */
 interface GetSamplesInfoInput {
 
     /**
-     * This method calls the output interface with the codes of samples in the project
-     * that have available data attached
+     * This method calls the output interface with the codes and names of samples in the project
+     * that have a certain status
      * In case of failure the output interface failure method is called.
      *
      * @param projectCode a code specifying the samples that should be considered
+     * @param status a kind of sample status matching a category in the sample tracking database
      * @since 1.0.0
      */
     void requestSampleInfosFor(String projectCode, Status status)

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
@@ -5,7 +5,7 @@ import life.qbic.datamodel.samples.Status
 /**
  * <b>Input interface for the {@link GetSamplesInfo} feature</b>
  *
- * <p>Provides methods to trigger the fetching of sample codes and names of samples with provided status for one project</p>>
+ * <p>Provides methods to trigger the fetching of sample codes and names of samples with provided status for one project</p>
  *
  * @since 1.0.0
  */

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoInput.groovy
@@ -12,9 +12,9 @@ import life.qbic.datamodel.samples.Status
 interface GetSamplesInfoInput {
 
     /**
-     * This method calls the output interface with the codes and names of samples in the project
-     * that have a certain status
-     * In case of failure the output interface failure method is called.
+     * <p>This method calls the output interface with the codes and names of samples in the project
+     * that have a certain status</p>
+     * <p>In case of failure the output interface failure method is called.</p>
      *
      * @param projectCode a code specifying the samples that should be considered
      * @param status a kind of sample status matching a category in the sample tracking database

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
@@ -3,26 +3,26 @@ package life.qbic.business.samples.info
 import life.qbic.datamodel.samples.Status
 
 /**
- * <b>Output interface for the {@link DownloadSamples} feature</b>
+ * <b>Output interface for the {@link GetSamplesInfo} feature</b>
  *
- * <p>Returns results from finding sample codes with downloadable data for one project</p>
+ * <p>Returns results from finding sample codes with respective names for one type of sample status and one project</p>
  *
  * @since 1.0.0
  */
 interface GetSamplesInfoOutput {
 
     /**
-     * To be called when the execution of the fetching sample codes failed
-     * @param reason the reason why the samples retrieval failed
+     * To be called when the execution of the fetching sample codes or respective info failed
+     * @param reason the reason why the sample or sample info retrieval failed
      * @since 1.0.0
      */
     void failedExecution(String reason)
 
     /**
-     * To be called after successfully fetching sample codes with data for the provided code.
-     * @param projectCode the code of the project samples were counted for
-     * @param status the code of the project samples were counted for
-     * @param sampleCodesToNames list of sample codes with available data
+     * To be called after successfully fetching sample codes with respective sample names for the provided project and status.
+     * @param projectCode the code of the project samples should be returned for
+     * @param status the status of the samples that should be returned
+     * @param sampleCodesToNames list of sample codes with names
      * @since 1.0.0
      */
     void samplesWithNames(String projectCode, Status status, Map<String, String> sampleCodesToNames)

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
@@ -1,0 +1,30 @@
+package life.qbic.business.samples.info
+
+import life.qbic.datamodel.samples.Status
+
+/**
+ * <b>Output interface for the {@link DownloadSamples} feature</b>
+ *
+ * <p>Returns results from finding sample codes with downloadable data for one project</p>
+ *
+ * @since 1.0.0
+ */
+interface GetSamplesInfoOutput {
+
+    /**
+     * To be called when the execution of the fetching sample codes failed
+     * @param reason the reason why the samples retrieval failed
+     * @since 1.0.0
+     */
+    void failedExecution(String reason)
+
+    /**
+     * To be called after successfully fetching sample codes with data for the provided code.
+     * @param projectCode the code of the project samples were counted for
+     * @param status the code of the project samples were counted for
+     * @param sampleCodesToNames list of sample codes with available data
+     * @since 1.0.0
+     */
+    void samplesWithNames(String projectCode, Status status, Map<String, String> sampleCodesToNames)
+
+}

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfoOutput.groovy
@@ -5,7 +5,6 @@ import life.qbic.datamodel.samples.Status
 /**
  * <b>Output interface for the {@link GetSamplesInfo} feature</b>
  *
- * <p>Returns results from finding sample codes with respective names for one type of sample status and one project</p>
  *
  * @since 1.0.0
  */

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
@@ -12,7 +12,7 @@ import spock.lang.Specification
  */
 class GetSamplesInfoSpec extends Specification {
   
-    def "successful execution of the use case forwards a map"() {
+    def "successful execution of the use case forwards the map of found samples"() {
         
         given:
         DownloadSamplesDataSource sampleDataSource = Stub()

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
@@ -38,7 +38,7 @@ class GetSamplesInfoSpec extends Specification {
     }
 
     
-    def "unsuccessful execution of the use case leads to failure notification"() {
+    def "unsuccessful execution of the use case does not lead to failure notification, but forwards the exception"() {
         
         given:
         DownloadSamplesDataSource sampleDataSource = Stub()
@@ -54,11 +54,13 @@ class GetSamplesInfoSpec extends Specification {
         when:"the use case is run"
         getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
         
-        then:"a failure message is send"
-        1 * output.failedExecution(_)
+        then:"exception is not caught"
+        0 * output.failedExecution(_)
         0 * output.samplesWithNames(_)
+        RuntimeException ex = thrown()
+        ex.message == "Testing runtime exceptions"
     }
-
+    
     def "a DataSourceException leads to a failure notification and no sample codes being loaded"() {
         
         given:
@@ -66,7 +68,7 @@ class GetSamplesInfoSpec extends Specification {
         GetSamplesInfoDataSource infoDataSource = Stub()
         String projectCode = "QABCD"
         sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { new ArrayList<String>() }
-        infoDataSource.fetchSampleNamesFor(_) >> { 
+        infoDataSource.fetchSampleNamesFor(_) >> {
             throw new DataSourceException("Testing data source exception")
         }
         GetSamplesInfoOutput output = Mock()
@@ -76,7 +78,7 @@ class GetSamplesInfoSpec extends Specification {
         getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
         
         then:"a failure message is send"
-        1 * output.failedExecution(_)   
+        1 * output.failedExecution(_)
         0 * output.samplesWithNames(_)
     }
 

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
@@ -1,0 +1,78 @@
+package life.qbic.business.samples.info
+
+import life.qbic.business.samples.download.DownloadSamplesDataSource
+import life.qbic.business.DataSourceException
+import life.qbic.datamodel.samples.Status
+import spock.lang.Specification
+
+/**
+ * <b>Tests the download samples use case</b>
+ *
+ * @since 1.0.0
+ */
+class GetSamplesInfoSpec extends Specification {
+  
+    def "successful execution of the use case lead to success notifications"() {
+        
+        given:
+        DownloadSamplesDataSource sampleDataSource = Stub()
+        GetSamplesInfoDataSource infoDataSource = Stub()
+        String projectCode = "QABCD"
+        List<String> codes = ["QABCD001AB", "QABCD002AC", "QABCD005AX", "QABCD019A2"]
+        sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { new ArrayList<String>() }
+        infoDataSource.fetchSampleNamesFor(codes) >> { new HashMap<String,String>() }
+        GetSamplesInfoOutput output = Mock()
+        GetSamplesInfo getInfos = new GetSamplesInfo(sampleDataSource, infoDataSource, output)
+        
+        when:"the use case is run"
+        getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
+        
+        then:"a successful message is send"
+        1 * output.samplesWithNames(projectCode, Status.SAMPLE_QC_FAIL, _ as Map<String, String>)
+        0 * output.failedExecution(_ as String)
+    }
+
+    
+    def "unsuccessful execution of the use case lead to failure notifications"() {
+        
+        given:
+        DownloadSamplesDataSource sampleDataSource = Stub()
+        GetSamplesInfoDataSource infoDataSource = Stub()
+        String projectCode = "QABCD"
+        sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { new ArrayList<String>() }
+        infoDataSource.fetchSampleNamesFor(_) >> { 
+            throw new RuntimeException("Testing runtime exceptions")
+        }
+        GetSamplesInfoOutput output = Mock()
+        GetSamplesInfo getInfos = new GetSamplesInfo(sampleDataSource, infoDataSource, output)
+        
+        when:"the use case is run"
+        getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
+        
+        then:"a failure message is send"
+        1 * output.failedExecution(_)
+        0 * output.samplesWithNames(_)
+    }
+
+    def "a DataSourceException leads to a failure notification and no sample codes being loaded"() {
+        
+        given:
+        DownloadSamplesDataSource sampleDataSource = Stub()
+        GetSamplesInfoDataSource infoDataSource = Stub()
+        String projectCode = "QABCD"
+        sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { new ArrayList<String>() }
+        infoDataSource.fetchSampleNamesFor(_) >> { 
+            throw new DataSourceException("Testing data source exception")
+        }
+        GetSamplesInfoOutput output = Mock()
+        GetSamplesInfo getInfos = new GetSamplesInfo(sampleDataSource, infoDataSource, output)
+        
+        when:"the use case is run"
+        getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
+        
+        then:"a failure message is send"
+        1 * output.failedExecution(_)   
+        0 * output.samplesWithNames(_)
+    }
+
+}

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
@@ -33,7 +33,7 @@ class GetSamplesInfoSpec extends Specification {
     }
 
     
-    def "unsuccessful execution of the use case lead to failure notifications"() {
+    def "unsuccessful execution of the use case leads to failure notification"() {
         
         given:
         DownloadSamplesDataSource sampleDataSource = Stub()

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/info/GetSamplesInfoSpec.groovy
@@ -12,15 +12,20 @@ import spock.lang.Specification
  */
 class GetSamplesInfoSpec extends Specification {
   
-    def "successful execution of the use case lead to success notifications"() {
+    def "successful execution of the use case forwards a map"() {
         
         given:
         DownloadSamplesDataSource sampleDataSource = Stub()
         GetSamplesInfoDataSource infoDataSource = Stub()
         String projectCode = "QABCD"
         List<String> codes = ["QABCD001AB", "QABCD002AC", "QABCD005AX", "QABCD019A2"]
-        sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { new ArrayList<String>() }
-        infoDataSource.fetchSampleNamesFor(codes) >> { new HashMap<String,String>() }
+        Map<String, String> mapWithNames = new HashMap<>()
+        mapWithNames.put("QABCD001AB", "one")
+        mapWithNames.put("QABCD002AC", "two")
+        mapWithNames.put("QABCD005AX", "green")
+        mapWithNames.put("QABCD019A2", "blue")
+        sampleDataSource.fetchSampleCodesFor(projectCode, Status.SAMPLE_QC_FAIL) >> { codes }
+        infoDataSource.fetchSampleNamesFor(codes) >> { mapWithNames }
         GetSamplesInfoOutput output = Mock()
         GetSamplesInfo getInfos = new GetSamplesInfo(sampleDataSource, infoDataSource, output)
         
@@ -28,7 +33,7 @@ class GetSamplesInfoSpec extends Specification {
         getInfos.requestSampleInfosFor(projectCode, Status.SAMPLE_QC_FAIL)
         
         then:"a successful message is send"
-        1 * output.samplesWithNames(projectCode, Status.SAMPLE_QC_FAIL, _ as Map<String, String>)
+        1 * output.samplesWithNames(projectCode, Status.SAMPLE_QC_FAIL, mapWithNames)
         0 * output.failedExecution(_ as String)
     }
 


### PR DESCRIPTION
Adds use case that fetches sample codes and metadata (names) of samples of a specific status and project. to be used for samples that failed QC.