### PR TITLE
Add download of manifest file

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/Constants.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/Constants.groovy
@@ -1,0 +1,12 @@
+package life.qbic.portal.sampletracking
+
+/**
+ * <b>Class providing constant information over the whole application.</b>
+ *
+ * <p>Information included in this class are valid in the whole scope. Use with care!</p>
+ *
+ * @since 1.0.0
+ */
+class Constants {
+    public static final String CONTACT_HELPDESK = "Please contact support@qbic.zendesk.com"
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
+import life.qbic.business.OutputException
 import life.qbic.business.samples.count.CountSamplesOutput
 import life.qbic.datamodel.samples.Status
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
@@ -28,7 +29,11 @@ class CountSamplesPresenter implements CountSamplesOutput {
      */
     @Override
     void failedExecution(String reason) {
-        notificationService.publishFailure("Failed to count samples: $reason")
+        try {
+            notificationService.publishFailure("Failed to count samples: $reason")
+        } catch (Exception e) {
+            throw new OutputException(e.getMessage())
+        }
     }
 
     /**
@@ -38,13 +43,21 @@ class CountSamplesPresenter implements CountSamplesOutput {
      */
     @Override
     void countedReceivedSamples(String projectCode, int allSamples, int receivedSamples) {
-        StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_RECEIVED, receivedSamples)
-        statusCountResourceService.addToResource(statusCount)
+        try {
+            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_RECEIVED, receivedSamples)
+            statusCountResourceService.addToResource(statusCount)
+        } catch (Exception e) {
+            throw new OutputException(e.getMessage())
+        }
     }
 
     @Override
     void countedFailedQcSamples(String projectCode, int allSamples, int receivedSamples) {
-        StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_QC_FAIL, receivedSamples)
-        statusCountResourceService.addToResource(statusCount)
+        try {
+            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_QC_FAIL, receivedSamples)
+            statusCountResourceService.addToResource(statusCount)
+        } catch (Exception e) {
+            throw new OutputException(e.getMessage())
+        }
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -59,9 +59,18 @@ class ProjectOverviewView extends VerticalLayout{
                 it.getSelectedItem().ifPresent(this::selectProject)
             }
         })
-        //todo here a recursion is created!
         viewModel.addPropertyChangeListener("selectedProject", {
-            if (viewModel.selectedProject) {
+            Optional<ProjectSummary> modelSelection = Optional.ofNullable(viewModel.selectedProject)
+            Optional<ProjectSummary> viewSelection = projectGrid.getSelectionModel().getFirstSelectedItem()
+            boolean viewModelHoldsSelection = modelSelection.isPresent()
+            boolean viewSelectionEqualsModelSelection
+            if (viewSelection.isPresent() && modelSelection.isPresent()) {
+                viewSelectionEqualsModelSelection = viewSelection.get() == modelSelection.get()
+            } else {
+                viewSelectionEqualsModelSelection = false
+            }
+
+            if (viewModelHoldsSelection && !viewSelectionEqualsModelSelection) {
                 projectGrid.select(viewModel.selectedProject)
             } else {
                 projectGrid.deselectAll()
@@ -132,7 +141,7 @@ class ProjectOverviewView extends VerticalLayout{
 
     private void tryToDownloadManifest() {
         try {
-            Optional.ofNullable(viewModel.selectedProject).ifPresent({
+            Optional.ofNullable(viewModel.selectedProject).filter({it.sampleDataAvailable > 0 }).ifPresent({
                 String projectCode = it.getCode()
                 downloadProjectController.downloadProject(projectCode)
             })

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -59,8 +59,12 @@ class ProjectOverviewView extends VerticalLayout{
                 it.getSelectedItem().ifPresent(this::selectProject)
             }
         })
-        viewModel.addPropertyChangeListener("selectedProjectCode", {
-            projectGrid.select(viewModel.selectedProject)
+        viewModel.addPropertyChangeListener("selectedProject", {
+            if (viewModel.selectedProject) {
+                projectGrid.select(viewModel.selectedProject)
+            } else {
+                projectGrid.deselectAll()
+            }
         })
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -8,6 +8,7 @@ import com.vaadin.server.StreamResource
 import com.vaadin.shared.ui.grid.HeightMode
 import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
+import life.qbic.portal.sampletracking.Constants
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.download.DownloadProjectController
 
@@ -65,11 +66,7 @@ class ProjectOverviewView extends VerticalLayout{
 
     private void selectProject(ProjectSummary projectSummary) {
         viewModel.selectedProject = projectSummary
-        try {
-            tryToDownloadManifest()
-        } catch (IllegalArgumentException illegalArgument) {
-            notificationService.publishFailure("Manifest Download failed due to: ${illegalArgument.getMessage()}")
-        }
+        tryToDownloadManifest()
     }
 
     private void clearProjectSelection() {
@@ -124,11 +121,17 @@ class ProjectOverviewView extends VerticalLayout{
         return buttonBar
     }
 
-    private void tryToDownloadManifest() throws IllegalArgumentException{
-        Optional.ofNullable(viewModel.selectedProject).ifPresent({
-            String projectCode = it.getCode()
-            downloadProjectController.downloadProject(projectCode)
-        })
+    private void tryToDownloadManifest() {
+        try {
+            Optional.ofNullable(viewModel.selectedProject).ifPresent({
+                String projectCode = it.getCode()
+                downloadProjectController.downloadProject(projectCode)
+            })
+        } catch (IllegalArgumentException illegalArgument) {
+            notificationService.publishFailure("Manifest Download failed due to: ${illegalArgument.getMessage()}")
+        } catch (Exception ignored) {
+            notificationService.publishFailure("Manifest Download failed for unknown reasons. ${Constants.CONTACT_HELPDESK}")
+        }
     }
 
     private void enableWhenDownloadIsAvailable(Component component) {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -28,7 +28,6 @@ class ProjectOverviewView extends VerticalLayout{
 
     private Label titleLabel
     private Grid<ProjectSummary> projectGrid
-    private TextArea manifestArea
 
     final static int MAX_CODE_COLUMN_WIDTH = 400
     final static int MAX_STATUS_COLUMN_WIDTH = 200
@@ -46,8 +45,7 @@ class ProjectOverviewView extends VerticalLayout{
         titleLabel = new Label("Project Overview")
         titleLabel.addStyleName(ValoTheme.LABEL_LARGE)
         setupProjects()
-        manifestArea = setupManifestContent()
-        this.addComponents(titleLabel,setupProjectSpecificButtons(), projectGrid,manifestArea)
+        this.addComponents(titleLabel,setupProjectSpecificButtons(), projectGrid)
     }
 
     private void setupProjects(){
@@ -105,16 +103,6 @@ class ProjectOverviewView extends VerticalLayout{
         projectGrid.setDataProvider(dataProvider)
     }
 
-    private TextArea setupManifestContent() {
-        TextArea textArea = new TextArea("Download Manifest")
-        textArea.setReadOnly(true)
-        setVisibleWhenDownloadIsAvailable(textArea)
-        viewModel.addPropertyChangeListener("generatedManifest", {
-            textArea.setValue(Optional.ofNullable(it.newValue).orElse("") as String)
-        })
-        return textArea
-    }
-
     private AbstractComponent setupProjectSpecificButtons() {
         VerticalLayout buttonBar = new VerticalLayout()
         buttonBar.setMargin(false)
@@ -147,13 +135,6 @@ class ProjectOverviewView extends VerticalLayout{
         component.enabled = isDownloadAvailable()
         viewModel.addPropertyChangeListener("generatedManifest") {
             component.enabled = isDownloadAvailable()
-        }
-    }
-
-    private void setVisibleWhenDownloadIsAvailable(Component component) {
-        component.visible = isDownloadAvailable()
-        viewModel.addPropertyChangeListener("generatedManifest") {
-            component.visible = isDownloadAvailable()
         }
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -59,6 +59,7 @@ class ProjectOverviewView extends VerticalLayout{
                 it.getSelectedItem().ifPresent(this::selectProject)
             }
         })
+        //todo here a recursion is created!
         viewModel.addPropertyChangeListener("selectedProject", {
             if (viewModel.selectedProject) {
                 projectGrid.select(viewModel.selectedProject)

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -62,19 +62,19 @@ class ProjectOverviewView extends VerticalLayout{
         viewModel.addPropertyChangeListener("selectedProject", {
             Optional<ProjectSummary> modelSelection = Optional.ofNullable(viewModel.selectedProject)
             Optional<ProjectSummary> viewSelection = projectGrid.getSelectionModel().getFirstSelectedItem()
-            boolean viewModelHoldsSelection = modelSelection.isPresent()
-            boolean viewSelectionEqualsModelSelection
-            if (viewSelection.isPresent() && modelSelection.isPresent()) {
-                viewSelectionEqualsModelSelection = viewSelection.get() == modelSelection.get()
-            } else {
-                viewSelectionEqualsModelSelection = false
-            }
+            modelSelection.ifPresent({
+                if (viewSelection.isPresent()) {
+                    if (viewSelection.get() == modelSelection.get()) {
+                        // do nothing
+                    } else {
+                        projectGrid.getSelectionModel().deselectAll()
+                        projectGrid.select(modelSelection.get())
+                    }
+                } else {
+                    projectGrid.select(modelSelection.get())
+                }
+            })
 
-            if (viewModelHoldsSelection && !viewSelectionEqualsModelSelection) {
-                projectGrid.select(viewModel.selectedProject)
-            } else {
-                projectGrid.deselectAll()
-            }
         })
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -137,11 +137,10 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void tryToDownloadManifest() throws IllegalArgumentException{
-        String projectCode = null
         Optional.ofNullable(viewModel.selectedProject).ifPresent({
-            projectCode = it.getCode()
+            String projectCode = it.getCode()
+            downloadProjectController.downloadProject(projectCode)
         })
-        downloadProjectController.downloadProject(projectCode)
     }
 
     private void enableWhenDownloadIsAvailable(Component component) {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -75,4 +75,9 @@ class ProjectOverviewViewModel {
         }
         projectOverview.samplesQcFailed = sampleCount
     }
+
+    InputStream getManifestInputStream() {
+        InputStream result =  new ByteArrayInputStream(generatedManifest.getBytes())
+        return result
+    }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -13,8 +13,8 @@ import life.qbic.datamodel.dtos.projectmanagement.Project
  */
 @EqualsAndHashCode
 class ProjectSummary {
-    private String code
-    private String title
+    final String code
+    final String title
     int samplesReceived
     int samplesQcFailed
     int sampleDataAvailable

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/download/ManifestPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/download/ManifestPresenter.groovy
@@ -24,7 +24,8 @@ class ManifestPresenter implements ComposeManifestOutput {
 
     @Override
     void readManifest(String printedManifest) {
-        viewModel.generatedManifest = Optional.ofNullable(printedManifest).orElse("")
+        String newValue = Optional.ofNullable(printedManifest).orElse("")
+        viewModel.setGeneratedManifest(newValue)
     }
 
     @Override

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/download/ManifestPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/download/ManifestPresenter.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.sampletracking.components.projectoverview.download
 
+import life.qbic.business.OutputException
 import life.qbic.business.samples.download.ComposeManifestOutput
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
@@ -24,12 +25,20 @@ class ManifestPresenter implements ComposeManifestOutput {
 
     @Override
     void readManifest(String printedManifest) {
-        String newValue = Optional.ofNullable(printedManifest).orElse("")
-        viewModel.setGeneratedManifest(newValue)
+        try {
+            String newValue = Optional.ofNullable(printedManifest).orElse("")
+            viewModel.setGeneratedManifest(newValue)
+        } catch (Exception e) {
+            throw new OutputException(e.getMessage())
+        }
     }
 
     @Override
     void failedExecution(String reason) {
-        notificationService.publishFailure("Could not create download manifest. Reason: $reason")
+        try {
+            notificationService.publishFailure("Could not create download manifest. Reason: $reason")
+        } catch (Exception e) {
+            throw new OutputException(e.getMessage())
+        }
     }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/OutputException.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/OutputException.groovy
@@ -1,0 +1,36 @@
+package life.qbic.business
+
+/**
+ * <b>Indicates an exception of the use case output</b>
+ *
+ * <p>Intended to be thrown by use case output methods.
+ * This exception indicates that the output implementation failed.</p>
+ *
+ * @since 1.0.0
+ */
+class OutputException extends RuntimeException {
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a call to initCause.
+     *
+     * @param message the detail message. The detail message is saved for later retrieval by the getMessage() method
+     * @since 1.0.0
+     */
+    OutputException(String message) {
+        super(message)
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and cause.
+     Note that the detail message associated with cause is not automatically incorporated in this runtime exception's detail message.
+
+     * @param message the detailed message (which is saved for later retrieval by the getMessage() method).
+     * @param cause  the cause (which is saved for later retrieval by the getCause() method).
+     *  (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
+     * @since 1.0.0
+     */
+    OutputException(String message, Throwable cause) {
+        super(message, cause)
+    }
+}

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.samples.count
 
+import life.qbic.business.OutputException
+
 /**
  * <b>Output interface for the {@link CountSamples} feature</b>
  *
@@ -14,7 +16,7 @@ interface CountSamplesOutput {
      * @param reason the reason why the samples retrieval failed
      * @since 1.0.0
      */
-    void failedExecution(String reason)
+    void failedExecution(String reason) throws OutputException
 
     /**
      * To be called after successfully counting received samples for the provided code.
@@ -22,7 +24,7 @@ interface CountSamplesOutput {
      * @param projectCode the code of the project samples were counted for
      * @since 1.0.0
      */
-    void countedReceivedSamples(String projectCode, int allSamples, int receivedSamples)
+    void countedReceivedSamples(String projectCode, int allSamples, int receivedSamples) throws OutputException
 
     /**
      * To be called after successfully counting failed QC samples for the provided code.
@@ -30,5 +32,5 @@ interface CountSamplesOutput {
      * @param projectCode the code of the project samples were counted for
      * @since 1.0.0
      */
-    void countedFailedQcSamples(String projectCode, int allSamples, int failedQcSamples)
+    void countedFailedQcSamples(String projectCode, int allSamples, int failedQcSamples) throws OutputException
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/ComposeManifest.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/ComposeManifest.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.samples.download
 
+import life.qbic.business.OutputException
+
 /**
  * <b>Compose a download manifest based on the output of {@link DownloadSamplesOutput}</b>
  *
@@ -26,12 +28,16 @@ class ComposeManifest implements DownloadSamplesOutput{
 
     @Override
     void foundDownloadableSamples(String projectCode, List<String> sampleCodes) {
-        if (sampleCodes.empty) {
-            output.failedExecution("There are no downloadable samples for ${projectCode}.")
-            return
+        try {
+            if (sampleCodes.empty) {
+                output.failedExecution("There are no downloadable samples for ${projectCode}.")
+                return
+            }
+            DownloadManifest downloadManifest = DownloadManifest.from(sampleCodes)
+            String printableManifest = DownloadManifestFormatter.format(downloadManifest)
+            output.readManifest(printableManifest)
+        } catch (Exception ignored) {
+            throw new OutputException("Could not generate manifest for samples: ${sampleCodes.toListString()}")
         }
-        DownloadManifest downloadManifest = DownloadManifest.from(sampleCodes)
-        String printableManifest = DownloadManifestFormatter.format(downloadManifest)
-        output.readManifest(printableManifest)
     }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
@@ -43,8 +43,6 @@ class DownloadSamples implements DownloadSamplesInput {
       output.foundDownloadableSamples(projectCode, sampleCodes)
     } catch (DataSourceException dataSourceException) {
       output.failedExecution(dataSourceException.getMessage())
-    } catch (Exception e) {
-      output.failedExecution("Could not fetch sample codes with available data.")
     }
   }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
@@ -1,6 +1,7 @@
 package life.qbic.business.samples.download
 
 import life.qbic.business.DataSourceException
+import life.qbic.business.OutputException
 import life.qbic.datamodel.samples.Status
 
 /**
@@ -43,6 +44,10 @@ class DownloadSamples implements DownloadSamplesInput {
       output.foundDownloadableSamples(projectCode, sampleCodes)
     } catch (DataSourceException dataSourceException) {
       output.failedExecution(dataSourceException.getMessage())
+    } catch (OutputException ignored) {
+      throw new RuntimeException("Could not forward results for ${projectCode}")
+    } catch (Exception ignored) {
+      throw new RuntimeException("Could not request sample codes for project ${projectCode}")
     }
   }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamples.groovy
@@ -1,6 +1,7 @@
 package life.qbic.business.samples.download
 
 import life.qbic.business.DataSourceException
+import life.qbic.business.OutputException
 import life.qbic.datamodel.samples.Status
 
 /**
@@ -38,11 +39,20 @@ class DownloadSamples implements DownloadSamplesInput {
     sampleCodes = new ArrayList<>()
     try {
       for(Status status : statusesWithData) {
-        sampleCodes.addAll(dataSource.fetchSampleCodesFor(projectCode, status))
+        List<String> sampleCodesForStatus = dataSource.fetchSampleCodesFor(projectCode, status)
+        // in groovy the addAll cannot be resolved correctly for some reason.
+        // Therefore it is handled this way. The Runtime is confused which addAll method to take
+        // and might throw a RuntimeException here for Collection#addAll, Iterator#addAll,
+        // List#addAll and ArrayList#addAll
+        sampleCodesForStatus.each {sampleCodes.add(it)}
       }
       output.foundDownloadableSamples(projectCode, sampleCodes)
     } catch (DataSourceException dataSourceException) {
       output.failedExecution(dataSourceException.getMessage())
+    } catch (OutputException ignored) {
+      throw new RuntimeException("Could not forward results for ${projectCode}")
+    } catch (Exception ignored) {
+      throw new RuntimeException("Could not request sample codes for project ${projectCode}")
     }
   }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamplesOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/download/DownloadSamplesOutput.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.samples.download
 
+import life.qbic.business.OutputException
+
 /**
  * <b>Output interface for the {@link DownloadSamples} feature</b>
  *
@@ -14,7 +16,7 @@ interface DownloadSamplesOutput {
      * @param reason the reason why the samples retrieval failed
      * @since 1.0.0
      */
-    void failedExecution(String reason)
+    void failedExecution(String reason) throws OutputException
 
     /**
      * To be called after successfully fetching sample codes with data for the provided code.
@@ -22,6 +24,6 @@ interface DownloadSamplesOutput {
      * @param sampleCodes list of sample codes with available data
      * @since 1.0.0
      */
-    void foundDownloadableSamples(String projectCode, List<String> sampleCodes)
+    void foundDownloadableSamples(String projectCode, List<String> sampleCodes) throws OutputException
 
 }

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
@@ -40,22 +40,6 @@ class DownloadSamplesSpec extends Specification {
         1 * output.foundDownloadableSamples(projectCode, codes)
         0 * output.failedExecution(_ as String)
     }
-    
-    def "unsuccessful execution of the use case lead to failure notifications"() {
-        given:
-        String projectCode = "QABCD"
-        DownloadSamplesDataSource dataSource = Stub()
-        dataSource.fetchSampleCodesFor(projectCode, Status.DATA_AVAILABLE) >> {
-            throw new RuntimeException("Testing runtime exceptions")
-        }
-        DownloadSamplesOutput output = Mock()
-        DownloadSamples downloadSamples = new DownloadSamples(dataSource, output)
-        when:"the use case is run"
-        downloadSamples.requestSampleCodesFor(projectCode)
-        then:"a failure message is send"
-        1 * output.failedExecution(_)
-        0 * output.foundDownloadableSamples(_)
-    }
 
     def "a DataSourceException leads to a failure notification and no sample codes being loaded"() {
         given:

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
@@ -1,6 +1,7 @@
 package life.qbic.business.samples.download
 
 import life.qbic.business.DataSourceException
+import life.qbic.business.OutputException
 import life.qbic.datamodel.samples.Status
 import spock.lang.Specification
 
@@ -39,6 +40,36 @@ class DownloadSamplesSpec extends Specification {
         then:"the correct amounts of samples are returned"
         1 * output.foundDownloadableSamples(projectCode, codes)
         0 * output.failedExecution(_ as String)
+    }
+
+    def "unsuccessful execution of the use case lead to failure notifications"() {
+        given:
+        String projectCode = "QABCD"
+        DownloadSamplesDataSource dataSource = Stub()
+        dataSource.fetchSampleCodesFor(projectCode, Status.DATA_AVAILABLE) >> {
+            throw new RuntimeException("Testing runtime exceptions")
+        }
+        DownloadSamplesOutput output = Mock()
+        DownloadSamples downloadSamples = new DownloadSamples(dataSource, output)
+        when:"the use case is run"
+        downloadSamples.requestSampleCodesFor(projectCode)
+        then:"a failure message is send"
+        1 * output.failedExecution(_)
+        0 * output.foundDownloadableSamples(_)
+    }
+
+    def "output failure leads to exception being thrown"() {
+        given:
+        String projectCode = "QABCD"
+        DownloadSamplesDataSource dataSource = Mock()
+        DownloadSamplesOutput output = Stub()
+        output.failedExecution(_ as String) >> { throw  new OutputException("Output failure does not work")}
+        output.foundDownloadableSamples(_ as String, _ as List<String>) >> { throw  new OutputException("Output success does not work")}
+        DownloadSamples downloadSamples = new DownloadSamples(dataSource, output)
+        when:"the use case is run"
+        downloadSamples.requestSampleCodesFor(projectCode)
+        then:"a runtime exception is thrown"
+        thrown(RuntimeException)
     }
 
     def "a DataSourceException leads to a failure notification and no sample codes being loaded"() {

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/download/DownloadSamplesSpec.groovy
@@ -62,7 +62,7 @@ class DownloadSamplesSpec extends Specification {
         String projectCode = "QABCD"
         DownloadSamplesDataSource dataSource = Mock()
         DownloadSamplesOutput output = Stub()
-        //output.failedExecution(_ as String) >> { throw  new OutputException("Output failure does not work")}
+        output.failedExecution(_ as String) >> { throw  new OutputException("Output failure does not work")}
         output.foundDownloadableSamples(_ as String, _ as List<String>) >> { throw  new OutputException("Output success does not work")}
         output.failedExecution(_ as String) >> {}
         DownloadSamples downloadSamples = new DownloadSamples(dataSource, output)


### PR DESCRIPTION
This Pr changes the behaviour of the UI.
The manifest content is now created upon project selection. The download is only available where a download manifest was created successfully. For projects without available data the download button is disabled.
