### PR TITLE
Extend use case to account for "Finished Library Prep" Status

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -66,4 +66,15 @@ class CountSamplesPresenter implements CountSamplesOutput {
         StatusCount statusCount = new StatusCount(projectCode, Status.DATA_AVAILABLE, availableData)
         statusCountResourceService.addToResource(statusCount)
     }
+
+    /**
+     * To be called after successfully counting samples with finished library prep for the provided code.
+     * @param number of all samples and samples that have available data
+     * @param projectCode the code of the project samples were counted for
+     * @since 1.0.0
+     */
+    @Override
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData) {
+
+    }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -74,7 +74,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
      * @since 1.0.0
      */
     @Override
-    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData) {
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int libraryPrepFinished) {
 
     }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
@@ -82,8 +82,8 @@ class CountSamples implements CountSamplesInput{
   void countLibraryPrepFinishedSamples(String projectCode) {
     try {
       sampleStatuses = dataSource.fetchSampleStatusesForProject(projectCode)
-      int availableData = countSamplesFromStatus(Status.LIBRARY_PREP_FINISHED)
-      output.countedAvailableSampleData(projectCode, sampleStatuses.size(), availableData)
+      int libraryPrepFinished = countSamplesFromStatus(Status.LIBRARY_PREP_FINISHED)
+      output.countedLibraryPrepFinishedSamples(projectCode, sampleStatuses.size(), libraryPrepFinished)
     } catch (Exception e) {
       output.failedExecution(e.getMessage())
     }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
@@ -78,6 +78,17 @@ class CountSamples implements CountSamplesInput{
     }
   }
 
+  @Override
+  void countLibraryPrepFinishedSamples(String projectCode) {
+    try {
+      sampleStatuses = dataSource.fetchSampleStatusesForProject(projectCode)
+      int availableData = countSamplesFromStatus(Status.LIBRARY_PREP_FINISHED)
+      output.countedAvailableSampleData(projectCode, sampleStatuses.size(), availableData)
+    } catch (Exception e) {
+      output.failedExecution(e.getMessage())
+    }
+  }
+
   private int countSamplesFromStatus(Status status) {
     int receivedIndex = statusesInOrder.indexOf(status)
     // statuses that are not considered in the ordered list return -1, meaning the sample is not counted

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
@@ -38,4 +38,14 @@ interface CountSamplesInput {
      * @since 1.0.0
      */
     void countAvailableDataSamples(String projectCode)
+
+    /**
+     * This method calls the output interface with the number of samples in the project
+     * and the number of samples for which the library prep is finished.
+     * In case of failure the output interface failure method is called.
+     *
+     * @param projectCode A code specifying the samples that should be considered
+     * @since 1.0.0
+     */
+    void countLibraryPrepFinishedSamples(String projectCode)
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
@@ -41,4 +41,12 @@ interface CountSamplesOutput {
      * @since 1.0.0
      */
     void countedAvailableSampleData(String projectCode, int allSamples, int availableData)
+
+    /**
+     * To be called after successfully counting samples with finished library prep for the provided code.
+     * @param number of all samples and samples that have available data
+     * @param projectCode the code of the project samples were counted for
+     * @since 1.0.0
+     */
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData)
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
@@ -48,5 +48,5 @@ interface CountSamplesOutput {
      * @param projectCode the code of the project samples were counted for
      * @since 1.0.0
      */
-    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData)
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int libraryPrepFinished)
 }


### PR DESCRIPTION
**Description of changes**
Includes LIBRARY_PREP_FINISHED sample status in `count_samples` Use Case

**Additional Information** 
Similiar to Use Case extension in PR #55 for DATA_AVAILABLE sample status 