### PR TITLE
Extend service with "Finished Library Prep" Status

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -161,6 +161,7 @@ class DependencyManager {
             countSamples.countReceivedSamples(it)
             countSamples.countQcFailedSamples(it)
             countSamples.countAvailableDataSamples(it)
+            countSamples.countLibraryPrepFinishedSamples(it)
         }
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
@@ -13,7 +13,7 @@ enum Topic {
     NOTIFICATION_SUCCESS("Success notification"),
     NOTIFICATION_INFO("Information notification"),
     SAMPLE_RECEIVED_COUNT_UPDATE("The count of received samples was updated"),
-    SAMPLE_FAILED_QC_COUNT_UPDATE("The c3ount of samples failing QC was updated"),
+    SAMPLE_FAILED_QC_COUNT_UPDATE("The count of samples failing QC was updated"),
     SAMPLE_DATA_AVAILABLE_COUNT_UPDATE("The count of available samples data was updated"),
     SAMPLE_LIBRARY_PREP_FINISHED("The count of samples with finished library prep was updated")
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
@@ -13,8 +13,9 @@ enum Topic {
     NOTIFICATION_SUCCESS("Success notification"),
     NOTIFICATION_INFO("Information notification"),
     SAMPLE_RECEIVED_COUNT_UPDATE("The count of received samples was updated"),
-    SAMPLE_FAILED_QC_COUNT_UPDATE("The count of samples failing QC was updated"),
-    SAMPLE_DATA_AVAILABLE_COUNT_UPDATE("The count of available samples data was updated")
+    SAMPLE_FAILED_QC_COUNT_UPDATE("The c3ount of samples failing QC was updated"),
+    SAMPLE_DATA_AVAILABLE_COUNT_UPDATE("The count of available samples data was updated"),
+    SAMPLE_LIBRARY_PREP_FINISHED("The count of samples with finished library prep was updated")
 
     @Override
     String toString() {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -66,4 +66,15 @@ class CountSamplesPresenter implements CountSamplesOutput {
         StatusCount statusCount = new StatusCount(projectCode, Status.DATA_AVAILABLE, availableData)
         statusCountResourceService.addToResource(statusCount)
     }
+
+    /**
+     * To be called after successfully counting samples with finished library prep for the provided code.
+     * @param number of all samples and samples that have available data
+     * @param projectCode the code of the project samples were counted for
+     * @since 1.0.0
+     */
+    @Override
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData) {
+
+    }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -75,6 +75,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
      */
     @Override
     void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData) {
-
+        StatusCount statusCount = new StatusCount(projectCode, Status.LIBRARY_PREP_FINISHED, availableData)
+        statusCountResourceService.addToResource(statusCount)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -48,6 +48,7 @@ class ProjectOverviewViewModel {
         this.statusCountService.subscribe({updateSamplesReceived(it.projectCode, it.count)}, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
         this.statusCountService.subscribe({updateSamplesFailedQc(it.projectCode, it.count)}, Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
         this.statusCountService.subscribe({updateDataAvailable(it.projectCode, it.count)}, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
+        this.statusCountService.subscribe({updateSamplesLibraryPrepFinished(it.projectCode, it.count)}, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
     }
 
     private void addProject(Project project) {
@@ -71,6 +72,10 @@ class ProjectOverviewViewModel {
 
     private void updateSamplesFailedQc(String projectCode, int sampleCount) {
         getProjectSummary(projectCode).samplesQcFailed = sampleCount
+    }
+
+    private void updateSamplesLibraryPrepFinished(String projectCode, int sampleCount){
+        getProjectSummary(projectCode).samplesLibraryPrepFinished = sampleCount
     }
 
     /**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceService.groovy
@@ -17,6 +17,7 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
         this.addTopic(Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
         this.addTopic(Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
         this.addTopic(Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
+        this.addTopic(Topic.SAMPLE_LIBRARY_PREP_FINISHED)
     }
 
     /**
@@ -38,6 +39,10 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
                 break
             case Status.DATA_AVAILABLE:
                 publish(statusCount, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
+                content.add(statusCount)
+                break
+            case Status.LIBRARY_PREP_FINISHED:
+                publish(statusCount, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
                 content.add(statusCount)
                 break
             default:
@@ -65,6 +70,10 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
                 break
             case Status.DATA_AVAILABLE:
                 publish(statusCount, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
+                content.remove(statusCount)
+                break
+            case Status.LIBRARY_PREP_FINISHED:
+                publish(statusCount, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
                 content.remove(statusCount)
                 break
             default:

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
@@ -16,7 +16,7 @@ class StatusCountResourceServiceSpec extends Specification {
     StatusCountResourceService statusCountService = new StatusCountResourceService()
     Subscriber<StatusCount> subscriber1 = Mock()
 
-    @Shared def knownStatuses = [Status.SAMPLE_RECEIVED, Status.SAMPLE_QC_FAIL, Status.DATA_AVAILABLE].sort { a, b -> a.name() <=> b.name()}
+    @Shared def knownStatuses = [Status.SAMPLE_RECEIVED, Status.SAMPLE_QC_FAIL, Status.DATA_AVAILABLE, Status.LIBRARY_PREP_FINISHED].sort { a, b -> a.name() <=> b.name()}
     @Shared def unknownStatuses = Status.values().findAll {! (it in knownStatuses)}.sort {a,b -> a.name() <=> b.name()}
 
     def "Removing and adding a count for #status informs all subscribers to #topic"() {

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamples.groovy
@@ -78,6 +78,17 @@ class CountSamples implements CountSamplesInput{
     }
   }
 
+  @Override
+  void countLibraryPrepFinishedSamples(String projectCode) {
+    try {
+      sampleStatuses = dataSource.fetchSampleStatusesForProject(projectCode)
+      int availableData = countSamplesFromStatus(Status.LIBRARY_PREP_FINISHED)
+      output.countedAvailableSampleData(projectCode, sampleStatuses.size(), availableData)
+    } catch (Exception e) {
+      output.failedExecution(e.getMessage())
+    }
+  }
+
   private int countSamplesFromStatus(Status status) {
     int receivedIndex = statusesInOrder.indexOf(status)
     // statuses that are not considered in the ordered list return -1, meaning the sample is not counted

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
@@ -38,4 +38,14 @@ interface CountSamplesInput {
      * @since 1.0.0
      */
     void countAvailableDataSamples(String projectCode)
+
+    /**
+     * This method calls the output interface with the number of samples in the project
+     * and the number of samples for which the library prep is finished.
+     * In case of failure the output interface failure method is called.
+     *
+     * @param projectCode A code specifying the samples that should be considered
+     * @since 1.0.0
+     */
+    void countLibraryPrepFinishedSamples(String projectCode)
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesOutput.groovy
@@ -41,4 +41,12 @@ interface CountSamplesOutput {
      * @since 1.0.0
      */
     void countedAvailableSampleData(String projectCode, int allSamples, int availableData)
+
+    /**
+     * To be called after successfully counting samples with finished library prep for the provided code.
+     * @param number of all samples and samples that have available data
+     * @param projectCode the code of the project samples were counted for
+     * @since 1.0.0
+     */
+    void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int availableData)
 }


### PR DESCRIPTION
**Description of changes**
Includes LIBRARY_PREP_FINISHED sample status in StatusCount services

**Additional Information**
Similiar to service extension in PR #56 for DATA_AVAILABLE sample status. 
The only difference is that this PR does not include adapting the view, since this is handled by another Sprint Task. 