### PR TITLE
Add check to avoid duplicate subscription of subscriber to project

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
@@ -89,16 +89,15 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
     
     private void addSubscription(Connection connection, int subscriberId, String projectCode) {
 
-          if (projectAlreadySubscribed(subscriberId, projectCode)) {
-              throw new DataSourceException("Subscriber is already subscribed to ${projectCode}")
+          if (!projectAlreadySubscribed(subscriberId, projectCode)) {
+              String query = "INSERT INTO subscription (project_code, subscriber_id) VALUES(?, ?)"
+
+              def statement = connection.prepareStatement(query)
+
+              statement.setInt(1, subscriberId)
+              statement.setString(2, projectCode)
+              statement.execute()
           }
-          String query = "INSERT INTO subscription (project_code, subscriber_id) VALUES(?, ?)"
-
-          def statement = connection.prepareStatement(query)
-
-          statement.setInt(1, subscriberId)
-          statement.setString(2, projectCode)
-          statement.execute()
     }
 
     private int fetchExistingSubscriberId(Subscriber subscriber) {
@@ -130,7 +129,8 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
                 statement.setString(1, projectCode)
                 statement.setString(2, subscriberId.toString())
                 ResultSet resultSet = statement.executeQuery()
-      if(resultSet.next()) isAlreadySubscribed = true
+                if(resultSet.next()){
+                    isAlreadySubscribed = true}
             }
         return isAlreadySubscribed
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
@@ -125,8 +125,6 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
         String query = "SELECT id FROM subscription WHERE project_code = ? AND subscriber_id = ? "
         Connection connection = connectionProvider.connect()
         boolean isAlreadySubscribed = false
-
-        try{
             connection.withCloseable {
                 def statement = connection.prepareStatement(query)
                 statement.setString(1, projectCode)
@@ -140,12 +138,6 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
                     isAlreadySubscribed = true
                 }
             }
-        }catch(Exception e){
-            log.error(e.message)
-            log.error(e.stackTrace.join("\n"))
-            connection.rollback()
-            throw new DataSourceException("Could not check if the subscriber is subscribed to project ${projectCode}")
-        }
         return isAlreadySubscribed
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
@@ -127,7 +127,7 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
             connection.withCloseable {
                 def statement = connection.prepareStatement(query)
                 statement.setString(1, projectCode)
-                statement.setString(2, subscriberId.toString())
+                statement.setInt(2, subscriberId)
                 ResultSet resultSet = statement.executeQuery()
                 if(resultSet.next()){
                     isAlreadySubscribed = true}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
@@ -130,13 +130,7 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
                 statement.setString(1, projectCode)
                 statement.setString(2, subscriberId.toString())
                 ResultSet resultSet = statement.executeQuery()
-                int numberOfRows = 0
-                while(resultSet.next()) {
-                    numberOfRows++
-                }
-                if (numberOfRows > 0) {
-                    isAlreadySubscribed = true
-                }
+      if(resultSet.next()) isAlreadySubscribed = true
             }
         return isAlreadySubscribed
     }


### PR DESCRIPTION
**Description of changes**
Addresses #94 

**Technical details**
Cheks if there is already an entry in the subscription table connecting the subscriber ID and the projectCode, before adding a subscription to the database. 

**Additional context**
Similiar to the method [offerAlreadyInDataSource()](https://github.com/qbicsoftware/offer-manager-2-portlet/blob/master/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy) used in the offer manager that checks if an offer is already stored before adding it to the database.