### PR TITLE
Wire Use Case to View Element 

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -136,7 +136,7 @@ class DependencyManager {
         ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel(projectResourceService, statusCountService)
         
         DownloadProjectController downloadController = setupDownloadProjectUsecase(viewModel)
-        SubscribeProjectController subscribeProjectController = setupSubscribeProjectUseCase(viewModel)
+        SubscribeProjectController subscribeProjectController = setupSubscribeProjectUseCase()
         ProjectOverviewView view =  new ProjectOverviewView(notificationService, viewModel, downloadController, subscribeProjectController, portalUser)
         return view
     }
@@ -148,8 +148,8 @@ class DependencyManager {
         return new DownloadProjectController(downloadSamples)
     }
 
-    private SubscribeProjectController setupSubscribeProjectUseCase(ProjectOverviewViewModel viewModel) {
-        SubscribeProjectOutput output = new SubscribeProjectPresenter(notificationService, viewModel)
+    private SubscribeProjectController setupSubscribeProjectUseCase() {
+        SubscribeProjectOutput output = new SubscribeProjectPresenter(notificationService)
         SubscribeProject subscribeProject = new SubscribeProject(subscriptionDataSource, output)
 
         return new SubscribeProjectController(subscribeProject)

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -7,6 +7,7 @@ import life.qbic.business.project.load.LoadProjectsInput
 import life.qbic.business.project.load.LoadProjectsOutput
 import life.qbic.business.project.subscribe.SubscribeProject
 import life.qbic.business.project.subscribe.SubscribeProjectOutput
+import life.qbic.business.project.subscribe.Subscriber
 import life.qbic.business.project.subscribe.SubscriptionDataSource
 import life.qbic.business.samples.count.CountSamples
 import life.qbic.business.samples.count.CountSamplesDataSource
@@ -133,11 +134,11 @@ class DependencyManager {
      * @return a new ProjectOverviewView
      */
     private ProjectOverviewView createProjectOverviewView() {
-        ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel(projectResourceService, statusCountService)
-        
+        Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
+        ProjectOverviewViewModel viewModel = new ProjectOverviewViewModel(projectResourceService, statusCountService, currentUser)
         DownloadProjectController downloadController = setupDownloadProjectUsecase(viewModel)
         SubscribeProjectController subscribeProjectController = setupSubscribeProjectUseCase()
-        ProjectOverviewView view =  new ProjectOverviewView(notificationService, viewModel, downloadController, subscribeProjectController, portalUser)
+        ProjectOverviewView view =  new ProjectOverviewView(notificationService, viewModel, downloadController, subscribeProjectController)
         return view
     }
     
@@ -151,7 +152,6 @@ class DependencyManager {
     private SubscribeProjectController setupSubscribeProjectUseCase() {
         SubscribeProjectOutput output = new SubscribeProjectPresenter(notificationService)
         SubscribeProject subscribeProject = new SubscribeProject(subscriptionDataSource, output)
-
         return new SubscribeProjectController(subscribeProject)
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -108,8 +108,7 @@ class DependencyManager {
         OpenBisConnector openBisConnector = new OpenBisConnector(openBisCredentials, portalUser, configurationManager.getDataSourceUrl() + "/openbis/openbis")
         loadProjectsDataSource = openBisConnector
 
-        SubscriptionsDbConnector subscriptionsDbConnector = new SubscriptionsDbConnector(DatabaseSession.getInstance())
-        subscriptionDataSource = subscriptionsDbConnector
+        subscriptionDataSource = new SubscriptionsDbConnector(DatabaseSession.getInstance())
     }
 
     /**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -9,9 +9,12 @@ import com.vaadin.shared.ui.ContentMode
 import com.vaadin.shared.ui.grid.HeightMode
 import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
+import life.qbic.business.project.subscribe.Subscriber
+import life.qbic.datamodel.dtos.portal.PortalUser
 import life.qbic.portal.sampletracking.Constants
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.download.DownloadProjectController
+import life.qbic.portal.sampletracking.components.projectoverview.subscribe.SubscribeProjectController
 
 /**
  * <b>This class generates the layout for the ProductOverview use case</b>
@@ -26,7 +29,9 @@ class ProjectOverviewView extends VerticalLayout{
 
     private final ProjectOverviewViewModel viewModel
     private final DownloadProjectController downloadProjectController
+    private final SubscribeProjectController subscribeProjectController
     private final NotificationService notificationService
+    private final PortalUser portalUser
 
     private Label titleLabel
     private Grid<ProjectSummary> projectGrid
@@ -35,11 +40,12 @@ class ProjectOverviewView extends VerticalLayout{
     final static int MAX_STATUS_COLUMN_WIDTH = 200
     private FileDownloader fileDownloader
 
-    ProjectOverviewView(NotificationService notificationService, ProjectOverviewViewModel viewModel, DownloadProjectController downloadProjectController){
+    ProjectOverviewView(NotificationService notificationService, ProjectOverviewViewModel viewModel, DownloadProjectController downloadProjectController, SubscribeProjectController subscribeProjectController, PortalUser portalUser){
         this.notificationService = notificationService
         this.viewModel = viewModel
         this.downloadProjectController = downloadProjectController
-
+        this.subscribeProjectController = subscribeProjectController
+        this.portalUser = portalUser
         initLayout()
     }
 
@@ -90,9 +96,14 @@ class ProjectOverviewView extends VerticalLayout{
         subscriptionCheckBox.setVisible(false)
         enableWhenProjectIsSelected(subscriptionCheckBox)
         subscriptionCheckBox.setValue(false)
+        subscriptionCheckBox.addValueChangeListener(event -> {
+            //Only Subscribe if checkbox is checked
+            if (subscriptionCheckBox.value) {
+                subscribeToProject(viewModel.selectedProject)
+            }
+        })
         return subscriptionCheckBox
     }
-
 
     private void setupProjects() {
         projectGrid = new Grid<>()
@@ -210,4 +221,12 @@ class ProjectOverviewView extends VerticalLayout{
             }
         }
     }
+
+    private void subscribeToProject(ProjectSummary project) {
+        Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
+        if(project){
+            subscribeProjectController.subscribeProject(currentUser ,project.code)
+        }
+    }
+
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -222,7 +222,7 @@ class ProjectOverviewView extends VerticalLayout{
         }
     }
 
-    private void subscribeToProject(ProjectSummary project) {
+    private void subscribeToProject(String projectCode) {
         Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
         if(project){
             subscribeProjectController.subscribeProject(currentUser ,project.code)

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -9,8 +9,6 @@ import com.vaadin.shared.ui.ContentMode
 import com.vaadin.shared.ui.grid.HeightMode
 import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
-import life.qbic.business.project.subscribe.Subscriber
-import life.qbic.datamodel.dtos.portal.PortalUser
 import life.qbic.portal.sampletracking.Constants
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.download.DownloadProjectController
@@ -31,7 +29,6 @@ class ProjectOverviewView extends VerticalLayout{
     private final DownloadProjectController downloadProjectController
     private final SubscribeProjectController subscribeProjectController
     private final NotificationService notificationService
-    private final PortalUser portalUser
 
     private Label titleLabel
     private Grid<ProjectSummary> projectGrid
@@ -40,12 +37,11 @@ class ProjectOverviewView extends VerticalLayout{
     final static int MAX_STATUS_COLUMN_WIDTH = 200
     private FileDownloader fileDownloader
 
-    ProjectOverviewView(NotificationService notificationService, ProjectOverviewViewModel viewModel, DownloadProjectController downloadProjectController, SubscribeProjectController subscribeProjectController, PortalUser portalUser){
+    ProjectOverviewView(NotificationService notificationService, ProjectOverviewViewModel viewModel, DownloadProjectController downloadProjectController, SubscribeProjectController subscribeProjectController){
         this.notificationService = notificationService
         this.viewModel = viewModel
         this.downloadProjectController = downloadProjectController
         this.subscribeProjectController = subscribeProjectController
-        this.portalUser = portalUser
         initLayout()
     }
 
@@ -223,10 +219,9 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void subscribeToProject(String projectCode) {
-        if (portalUser) {
-            Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
+        if (viewModel.subscriber) {
             if (projectCode) {
-                subscribeProjectController.subscribeProject(currentUser, projectCode)
+                subscribeProjectController.subscribeProject(viewModel.subscriber, projectCode)
             }
         }
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -98,8 +98,8 @@ class ProjectOverviewView extends VerticalLayout{
         subscriptionCheckBox.setValue(false)
         subscriptionCheckBox.addValueChangeListener(event -> {
             //Only Subscribe if checkbox is checked
-            if (subscriptionCheckBox.value) {
-                subscribeToProject(viewModel.selectedProject)
+            if (subscriptionCheckBox.value && viewModel.selectedProject) {
+                subscribeToProject(viewModel.selectedProject.code)
             }
         })
         return subscriptionCheckBox
@@ -223,10 +223,11 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void subscribeToProject(String projectCode) {
-        Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
-        if(project){
-            subscribeProjectController.subscribeProject(currentUser ,project.code)
+        if (portalUser) {
+            Subscriber currentUser = new Subscriber(portalUser.firstName, portalUser.lastName, portalUser.emailAddress)
+            if (projectCode) {
+                subscribeProjectController.subscribeProject(currentUser, projectCode)
+            }
         }
     }
-
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
 import groovy.beans.Bindable
+import life.qbic.business.project.subscribe.Subscriber
 import life.qbic.datamodel.dtos.projectmanagement.Project
 import life.qbic.portal.sampletracking.communication.Topic
 import life.qbic.portal.sampletracking.resource.ResourceService
@@ -22,10 +23,12 @@ class ProjectOverviewViewModel {
 
     @Bindable ProjectSummary selectedProject
     @Bindable String generatedManifest
+    final Subscriber subscriber
 
-    ProjectOverviewViewModel(ResourceService<Project> projectResourceService, ResourceService<StatusCount> statusCountService){
+    ProjectOverviewViewModel(ResourceService<Project> projectResourceService, ResourceService<StatusCount> statusCountService, Subscriber subscriber){
         this.projectResourceService = projectResourceService
         this.statusCountService = statusCountService
+        this.subscriber = subscriber
         fetchProjectData()
         subscribeToResources()
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectController.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectController.groovy
@@ -1,0 +1,37 @@
+package life.qbic.portal.sampletracking.components.projectoverview.subscribe
+
+import life.qbic.business.project.subscribe.SubscribeProject
+import life.qbic.business.project.subscribe.SubscribeProjectInput
+import life.qbic.business.project.subscribe.Subscriber
+
+/**
+ * <b>Controller allowing the view to call the subscribe project use case</b>
+ *
+ * <p>Used via the view to start the subscribe project use case with the currently selected project code and a provided subscriber. </p>
+ *
+ * @since 1.0.0
+ */
+class SubscribeProjectController {
+
+    SubscribeProjectInput subscribeProject
+
+    SubscribeProjectController(SubscribeProject subscribeProject) {
+        this.subscribeProject = subscribeProject
+    }
+    
+    /**
+     * Triggers the Subscribe Project case. If no project code or subscriber is provided, throws an {@link IllegalArgumentException}
+     * @param projectCode the code of the selected project
+     * @param projectCode the user that will be subscribed to the project
+     * @throws IllegalArgumentException in case the project code or subscriber is not provided
+     */
+    void subscribeProject(Subscriber subscriber, String projectCode) throws IllegalArgumentException{
+        if (! subscriber) {
+            throw new IllegalArgumentException("No subscriber provided for subscription.")
+        }
+        else if (! projectCode) {
+            throw new IllegalArgumentException("No project selected for subscription.")
+        }
+        subscribeProject.subscribe(subscriber, projectCode)
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectController.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectController.groovy
@@ -26,12 +26,6 @@ class SubscribeProjectController {
      * @throws IllegalArgumentException in case the project code or subscriber is not provided
      */
     void subscribeProject(Subscriber subscriber, String projectCode) throws IllegalArgumentException{
-        if (! subscriber) {
-            throw new IllegalArgumentException("No subscriber provided for subscription.")
-        }
-        else if (! projectCode) {
-            throw new IllegalArgumentException("No project selected for subscription.")
-        }
         subscribeProject.subscribe(subscriber, projectCode)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
@@ -3,18 +3,17 @@ package life.qbic.portal.sampletracking.components.projectoverview.subscribe
 import life.qbic.business.project.subscribe.SubscribeProjectOutput
 import life.qbic.business.project.subscribe.Subscriber
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
-import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
+import life.qbic.portal.sampletracking.Constants
 /**
- * <b>Presents a download manifest to the viewModel containing identifiers that point to associated data</b>
+ * <b>Presents the notification message informing about a successful or failed subscription along with the projectCode</b>
  *
- * <p>Is called from a use case with a manifest String containing identifiers (e.g. of samples) that have associated data.
- * This manifest is added to the view model in order to further use it, e.g. present it to the user.</p>
+ * <p>Is called from a use case with the projectCode for a successful subscription or with the projectCode and Subscriber on a failed subscription
+ * This information is added to the generated notification message to inform the user about his subscription status for the specified project</p>
  *
  * @since 1.0.0
  */
 class SubscribeProjectPresenter implements SubscribeProjectOutput {
 
-    private final ProjectOverviewViewModel viewModel
     private final NotificationService notificationService
 
     SubscribeProjectPresenter(NotificationService notificationService) {
@@ -41,7 +40,7 @@ class SubscribeProjectPresenter implements SubscribeProjectOutput {
     @Override
     void subscriptionFailed(Subscriber subscriber, String projectCode) {
         String message = "An unexpected while trying to subscribe to project ${projectCode}. " +
-                    "Please contact ${Constants.QBIC_HELPDESK_EMAIL}."
+                    "Please contact ${Constants.CONTACT_HELPDESK}."
         notificationService.publishFailure(message)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
@@ -1,0 +1,47 @@
+package life.qbic.portal.sampletracking.components.projectoverview.subscribe
+
+import life.qbic.business.project.subscribe.SubscribeProjectOutput
+import life.qbic.business.project.subscribe.Subscriber
+import life.qbic.portal.sampletracking.communication.notification.NotificationService
+import life.qbic.portal.sampletracking.components.projectoverview.ProjectOverviewViewModel
+/**
+ * <b>Presents a download manifest to the viewModel containing identifiers that point to associated data</b>
+ *
+ * <p>Is called from a use case with a manifest String containing identifiers (e.g. of samples) that have associated data.
+ * This manifest is added to the view model in order to further use it, e.g. present it to the user.</p>
+ *
+ * @since 1.0.0
+ */
+class SubscribeProjectPresenter implements SubscribeProjectOutput {
+
+    private final ProjectOverviewViewModel viewModel
+    private final NotificationService notificationService
+
+    SubscribeProjectPresenter(NotificationService notificationService, ProjectOverviewViewModel viewModel) {
+        this.notificationService = notificationService
+        this.viewModel = viewModel
+    }
+
+    /**
+    * A subscription was added for a given project
+    * @param project the project code of the subscribed project
+    * @since 1.1.0
+    */
+    @Override
+    void subscriptionAdded(String project) {
+        String message = "Subscription to ${project} was successful"
+        notificationService.publishSuccess(message)
+    }
+
+    /**
+     * A subscription was not possible
+     * @param subscriber the subscriber that was provided
+     * @param projectCode the project the subscription was attempted on
+     * @since 1.1.0
+     */
+    @Override
+    void subscriptionFailed(Subscriber subscriber, String projectCode) {
+        String message = "${subscriber} could not be subscribed to project ${projectCode}"
+        notificationService.publishFailure(message)
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
@@ -17,9 +17,8 @@ class SubscribeProjectPresenter implements SubscribeProjectOutput {
     private final ProjectOverviewViewModel viewModel
     private final NotificationService notificationService
 
-    SubscribeProjectPresenter(NotificationService notificationService, ProjectOverviewViewModel viewModel) {
+    SubscribeProjectPresenter(NotificationService notificationService) {
         this.notificationService = notificationService
-        this.viewModel = viewModel
     }
 
     /**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/subscribe/SubscribeProjectPresenter.groovy
@@ -41,7 +41,8 @@ class SubscribeProjectPresenter implements SubscribeProjectOutput {
      */
     @Override
     void subscriptionFailed(Subscriber subscriber, String projectCode) {
-        String message = "${subscriber} could not be subscribed to project ${projectCode}"
+        String message = "An unexpected while trying to subscribe to project ${projectCode}. " +
+                    "Please contact ${Constants.QBIC_HELPDESK_EMAIL}."
         notificationService.publishFailure(message)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/datasources/subscriptions/SubscriptionsDbConnector.groovy
@@ -77,7 +77,7 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
             
             statement.setString(1, subscriber.firstName)
             statement.setString(2, subscriber.lastName)
-            statement.setString(3, subscriber.eMail)
+            statement.setString(3, subscriber.email)
             statement.execute()
             def keys = statement.getGeneratedKeys()
             while (keys.next()) {
@@ -88,14 +88,13 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
     }
     
     private void addSubscription(Connection connection, int subscriberId, String projectCode) {
-
           if (!projectAlreadySubscribed(subscriberId, projectCode)) {
               String query = "INSERT INTO subscription (project_code, subscriber_id) VALUES(?, ?)"
 
               def statement = connection.prepareStatement(query)
 
-              statement.setInt(1, subscriberId)
-              statement.setString(2, projectCode)
+              statement.setString(1, projectCode)
+              statement.setInt(2, subscriberId)
               statement.execute()
           }
     }
@@ -110,7 +109,7 @@ class SubscriptionsDbConnector implements SubscriptionDataSource {
             def statement = connection.prepareStatement(query)
             statement.setString(1, subscriber.firstName)
             statement.setString(2, subscriber.lastName)
-            statement.setString(3, subscriber.eMail)
+            statement.setString(3, subscriber.email)
 
             ResultSet result = statement.executeQuery()
             while (result.next()) {

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/project/subscribe/SubscribeProjectOutput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/project/subscribe/SubscribeProjectOutput.groovy
@@ -1,11 +1,11 @@
 package life.qbic.business.project.subscribe
 
 /**
- * <b><short description></b>
+ * <b>Output interface for the {@link life.qbic.business.project.subscribe.SubscribeProject} feature</b>
  *
- * <p><detailed description></p>
+ * <p>Publishes the project code if a subscription was successful or the subscriber and projectCode if a subscription failed</p>
  *
- * @since <version tag>
+ * @since 1.0.0
  */
 interface SubscribeProjectOutput {
 


### PR DESCRIPTION
**Description of changes**
Wires the use case logic to the `ProjectOverViewView` via a controller/presenter pattern. 

**Technical details**
The `ProjectSubscription` Use case expects a subscriber and the projectCode. 
Currently this is done by passing the `portalUser` from the dependencyManager to the view, where a subscriber is constructed. I'd be happy for feedback on how to improve this implementation. 🤔 

**Additional context**
This PR also fixes minor errors in the `SubscriptionsDBConnector` class which popped up while testing the wiring. 

**How To Test**
Note: This Use Case just adds a subscriber to a project and we currently have no use case to see the subscribtion status in the View. 

Therefore to test the implementation you have to check the database for 2 things: 

1. the creation of a new entry in the subscriber table if the logged in User is not stored there yet. 
2. The creation of a new entry in the subscription table linking the logged in subscriber ID to the selected ProjectCode in the View