### PR TITLE
Add css and status states.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Color status counts based on the number of samples that have passed it (`#69 <https://github.com/qbicsoftware/sample-tracking-status-overview/issues/69>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -215,22 +215,22 @@ class ProjectOverviewView extends VerticalLayout{
         ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
             new RelativeCount(it.samplesReceived, it.totalSampleCount )
         }
-        projectGrid.addColumn(receivedProvider)
+        projectGrid.addColumn(receivedProvider).setStyleGenerator({getStyleForColumn(it, receivedProvider)})
                 .setCaption("Samples Received").setId("SamplesReceived")
         ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
             new RelativeCount(it.samplesQcFailed, it.totalSampleCount )
         }
         projectGrid.addColumn(failedQcProvider)
-                .setCaption("Samples Failed QC").setId("SamplesFailedQc")
+                .setCaption("Samples Failed QC").setId("SamplesFailedQc").setStyleGenerator({getStyleForFailureColumn(it, failedQcProvider)})
         ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = {ProjectSummary it ->
             new RelativeCount(it.samplesLibraryPrepFinished , it.totalSampleCount)
         }
         projectGrid.addColumn(libraryPrepProvider)
-                .setCaption("Library Prep Finished").setId("LibraryPrepFinished")
+                .setCaption("Library Prep Finished").setId("LibraryPrepFinished").setStyleGenerator({getStyleForColumn(it, libraryPrepProvider)})
         ValueProvider<ProjectSummary, RelativeCount> dataAvailableProvider = { ProjectSummary it ->
             new RelativeCount(it.sampleDataAvailable , it.totalSampleCount)
         }
-        projectGrid.addColumn(dataAvailableProvider)
+        projectGrid.addColumn(dataAvailableProvider).setStyleGenerator({getStyleForColumn(it, dataAvailableProvider)})
                 .setCaption("Data Available").setId("SampleDataAvailable")
         setupDataProvider()
         //specify size of grid and layout

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -214,22 +214,22 @@ class ProjectOverviewView extends VerticalLayout{
         projectGrid.addColumn({ it.title })
                 .setCaption("Project Title").setId("ProjectTitle")
         ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
-            new RelativeCount(it.samplesReceived, 100 ) //TODO replace this
+            new RelativeCount(it.samplesReceived, it.totalSampleCount)
         }
         projectGrid.addColumn(receivedProvider).setStyleGenerator({ getStyleForColumn(it, receivedProvider) })
                 .setCaption("Samples Received").setId("SamplesReceived")
         ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
-            new RelativeCount(it.samplesQcFailed, 100 ) //TODO replace this
+            new RelativeCount(it.samplesQcFailed, it.totalSampleCount)
         }
         projectGrid.addColumn(failedQcProvider).setStyleGenerator({ getStyleForFailureColumn(it, failedQcProvider) })
                 .setCaption("Samples Failed QC").setId("SamplesFailedQc")
-        ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = {ProjectSummary it ->
-            new RelativeCount(it.samplesLibraryPrepFinished , 100) //TODO replace this
+        ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = { ProjectSummary it ->
+            new RelativeCount(it.samplesLibraryPrepFinished, it.totalSampleCount)
         }
         projectGrid.addColumn(libraryPrepProvider).setStyleGenerator({ getStyleForColumn(it, libraryPrepProvider) })
                 .setCaption("Library Prep Finished").setId("LibraryPrepFinished")
         ValueProvider<ProjectSummary, RelativeCount> dataAvailableProvider = { ProjectSummary it ->
-            new RelativeCount(it.sampleDataAvailable , 100) //TODO replace this
+            new RelativeCount(it.sampleDataAvailable, it.totalSampleCount)
         }
         projectGrid.addColumn(dataAvailableProvider).setStyleGenerator({ getStyleForColumn(it, dataAvailableProvider) })
                 .setCaption("Data Available").setId("SampleDataAvailable")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -200,8 +200,7 @@ class ProjectOverviewView extends VerticalLayout{
 
     private static String getStyleForFailureColumn(ProjectSummary projectSummary, ValueProvider<ProjectSummary, RelativeCount> valueProvider) {
         RelativeCount relativeCount = valueProvider.apply(projectSummary)
-        int count = relativeCount.getValue()
-        State state = determineFailure(count)
+        State state = determineFailure(relativeCount)
         return state.getCssClass()
     }
 
@@ -319,12 +318,11 @@ class ProjectOverviewView extends VerticalLayout{
 
     /**
      * Determines the state of the current status. Is it in progress or were failures observed.
-     * @param samplesInStatus the count for the specific status
-     * @param totalSamples the total number of samples
+     * @param relativeCount
      * @return the state of the project for the status in question
      */
-    private static State determineFailure(int samplesInStatus) {
-        if (samplesInStatus > 0) {
+    private static State determineFailure(RelativeCount relativeCount) {
+        if (relativeCount.value > 0) {
             return State.FAILED
         } else {
             return State.IN_PROGRESS

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
@@ -1,0 +1,76 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * <b>A relative count of something.</b>
+ *
+ * <p>This class represents a relative count. It has a value that is a part of a total.</p>
+ *
+ * @since 1.0.0
+ */
+@EqualsAndHashCode
+class RelativeCount implements Comparable<RelativeCount> {
+    final int value
+    final int total
+
+    RelativeCount(int value, int total) {
+        this.value = value
+        this.total = total
+    }
+
+    @Override
+    String toString() {
+        return "$value / $total"
+    }
+    /**
+     * Compares this object with the specified object for order.  Returns a
+     * negative integer, zero, or a positive integer as this object is less
+     * than, equal to, or greater than the specified object.
+     *
+     * <p>The implementor must ensure <tt>sgn(x.compareTo(y)) ==
+     * -sgn(y.compareTo(x))</tt> for all <tt>x</tt> and <tt>y</tt>.  (This
+     * implies that <tt>x.compareTo(y)</tt> must throw an exception iff
+     * <tt>y.compareTo(x)</tt> throws an exception.)
+     *
+     * <p>The implementor must also ensure that the relation is transitive:
+     * <tt>(x.compareTo(y)&gt;0 &amp;&amp; y.compareTo(z)&gt;0)</tt> implies
+     * <tt>x.compareTo(z)&gt;0</tt>.
+     *
+     * <p>Finally, the implementor must ensure that <tt>x.compareTo(y)==0</tt>
+     * implies that <tt>sgn(x.compareTo(z)) == sgn(y.compareTo(z))</tt>, for
+     * all <tt>z</tt>.
+     *
+     * <p>It is strongly recommended, but <i>not</i> strictly required that
+     * <tt>(x.compareTo(y)==0) == (x.equals(y))</tt>.  Generally speaking, any
+     * class that implements the <tt>Comparable</tt> interface and violates
+     * this condition should clearly indicate this fact.  The recommended
+     * language is "Note: this class has a natural ordering that is
+     * inconsistent with equals."
+     *
+     * <p>In the foregoing description, the notation
+     * <tt>sgn(</tt><i>expression</i><tt>)</tt> designates the mathematical
+     * <i>signum</i> function, which is defined to return one of <tt>-1</tt>,
+     * <tt>0</tt>, or <tt>1</tt> according to whether the value of
+     * <i>expression</i> is negative, zero or positive.
+     *
+     * @param other the object to be compared.
+     * @return a negative integer, zero, or a positive integer as this object
+     *          is less than, equal to, or greater than the specified object.
+     *
+     * @throws NullPointerException if the specified object is null
+     * @throws ClassCastException if the specified object's type prevents it
+     *         from being compared to this object.
+     */
+    @Override
+    int compareTo(RelativeCount other) {
+        if (this.equals(other))  return 0
+        int valueComparison = this.value.compareTo(other.value)
+        if (valueComparison == 0) {
+            //if the value is equal compare the total
+            return this.total.compareTo(other.total)
+        } else {
+            return valueComparison
+        }
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/State.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/State.groovy
@@ -1,0 +1,33 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+
+/**
+ * <b>The state of a project status.</b>
+ *
+ * <p>A status can have the following states:
+ * <ul>
+ *     <li><b>COMPLETED</b>: When all samples in a project have reached this status and the status is not a failure status.</li>
+ *     <li><b>FAILED</b>: When a status is a failure status and samples are presently in the failed status.</li>
+ *     <li><b>IN_PROGRESS</b>: When not all samples were evaluated for the current status. <b>OR</b>: If the status is a failure status and there are not samples in the status.</li>
+ * </ul>
+ * </p>
+ *
+ * @since 1.0.0
+ */
+enum State {
+    COMPLETED("status-completed"),
+    FAILED("status-failed"),
+    IN_PROGRESS("status-in-progress")
+
+    /**
+     * The class in the CSS that should be assigned to the element.
+     * This does only contain the programmatic part of the css class and does not account for
+     * vaadin prefixes like <code>'.v-grid-cell.'</code>
+     * @since 1.0.0
+     */
+    final String cssClass
+
+    State(String cssClass) {
+        this.cssClass = cssClass
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -39,6 +39,18 @@
   /* Include all the styles from the valo theme */
   @include valo;
 
+  .v-grid-cell.status-completed {
+    background-color: green;
+  }
+
+  .v-grid-cell.status-in-progress {
+    background-color: gray;
+  }
+
+  .v-grid-cell.status-failed {
+    background-color: red;
+  }
+
   /* Insert your theme rules here */
   .portlet-footer {
     font-size: 9pt;

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -40,15 +40,15 @@
   @include valo;
 
   .v-grid-cell.status-completed {
-    background-color: green;
+    background-color: #b3e2cd;
   }
 
   .v-grid-cell.status-in-progress {
-    background-color: gray;
+    background-color: #cbd5e8;
   }
 
   .v-grid-cell.status-failed {
-    background-color: red;
+    background-color: #fdcdac;
   }
 
   /* Insert your theme rules here */


### PR DESCRIPTION
## Introduces colouring to grid status cells

This PR uses the fields of the `RelativeCount` to decide whether the status is complete or not. 
This is done via `CSS` by adding a StyleGenerator to the grid columns containing statuses. The column showing samples that failed QC is coloured differently from the other status columns.
The colouring is performed by the following rules:

### General rules

1. **Grey:** when the number of samples in this status is less than the total number of samples for the project
2. **Green:** when the number of samples is equal to the total number of samples for the project 

### Rules for FailedQC samples

1. **Grey:** when no samples are in the status FailedQC
2. **Red:** when one or more samples are in the status FailedQC



Depending on:
- [x] #104 

Solves:
- [x] #69

![image](https://user-images.githubusercontent.com/11536497/134335010-03ed9809-17c5-4d1b-b65a-416558d5d9c6.png)
