### PR TITLE
Visually indicate project status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Color status counts based on the number of samples that have passed it (`#69 <https://github.com/qbicsoftware/sample-tracking-status-overview/issues/69>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/DependencyManager.groovy
@@ -17,7 +17,6 @@ import life.qbic.business.samples.download.DownloadSamplesDataSource
 import life.qbic.business.samples.download.DownloadSamplesOutput
 import life.qbic.business.samples.info.GetSamplesInfo
 import life.qbic.business.samples.info.GetSamplesInfoDataSource
-import life.qbic.business.samples.info.GetSamplesInfoInput
 import life.qbic.business.samples.info.GetSamplesInfoOutput
 import life.qbic.datamodel.dtos.portal.PortalUser
 import life.qbic.datamodel.dtos.projectmanagement.Project
@@ -192,10 +191,7 @@ class DependencyManager {
             return it.projectId.projectCode.toString()
         }
         projectCodes.each {
-            countSamples.countReceivedSamples(it)
-            countSamples.countQcFailedSamples(it)
-            countSamples.countAvailableDataSamples(it)
-            countSamples.countLibraryPrepFinishedSamples(it)
+            countSamples.countSamplesPerStatus(it)
         }
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/CountSamplesPresenter.groovy
@@ -44,7 +44,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
     @Override
     void countedReceivedSamples(String projectCode, int allSamples, int receivedSamples) {
         try {
-            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_RECEIVED, receivedSamples)
+            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_RECEIVED, receivedSamples, allSamples)
             statusCountResourceService.addToResource(statusCount)
         } catch (Exception e) {
             throw new OutputException(e.getMessage())
@@ -54,7 +54,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
     @Override
     void countedFailedQcSamples(String projectCode, int allSamples, int receivedSamples) {
         try {
-            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_QC_FAIL, receivedSamples)
+            StatusCount statusCount = new StatusCount(projectCode, Status.SAMPLE_QC_FAIL, receivedSamples, allSamples)
             statusCountResourceService.addToResource(statusCount)
         } catch (Exception e) {
             throw new OutputException(e.getMessage())
@@ -63,7 +63,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
 
     @Override
     void countedAvailableSampleData(String projectCode, int allSamples, int availableData) {
-        StatusCount statusCount = new StatusCount(projectCode, Status.DATA_AVAILABLE, availableData)
+        StatusCount statusCount = new StatusCount(projectCode, Status.DATA_AVAILABLE, availableData, allSamples)
         statusCountResourceService.addToResource(statusCount)
     }
 
@@ -75,7 +75,7 @@ class CountSamplesPresenter implements CountSamplesOutput {
      */
     @Override
     void countedLibraryPrepFinishedSamples(String projectCode, int allSamples, int libraryPrepFinished) {
-        StatusCount statusCount = new StatusCount(projectCode, Status.LIBRARY_PREP_FINISHED, libraryPrepFinished)
+        StatusCount statusCount = new StatusCount(projectCode, Status.LIBRARY_PREP_FINISHED, libraryPrepFinished, allSamples)
         statusCountResourceService.addToResource(statusCount)
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
+import com.vaadin.data.ValueProvider
 import com.vaadin.data.provider.ListDataProvider
 import com.vaadin.event.selection.SingleSelectionEvent
 import com.vaadin.icons.VaadinIcons
@@ -12,9 +13,10 @@ import com.vaadin.ui.themes.ValoTheme
 import life.qbic.portal.sampletracking.Constants
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.download.DownloadProjectController
-import life.qbic.portal.sampletracking.components.projectoverview.subscribe.SubscribeProjectController
-import life.qbic.portal.sampletracking.components.projectoverview.samplelist.ProjectOverviewController
 import life.qbic.portal.sampletracking.components.projectoverview.samplelist.FailedQCSamplesView
+import life.qbic.portal.sampletracking.components.projectoverview.samplelist.ProjectOverviewController
+import life.qbic.portal.sampletracking.components.projectoverview.statusdisplay.RelativeCount
+import life.qbic.portal.sampletracking.components.projectoverview.subscribe.SubscribeProjectController
 
 /**
  * <b>This class generates the layout for the ProductOverview use case</b>
@@ -150,7 +152,7 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void setupProjects() {
-        projectGrid = new Grid<>()
+        projectGrid = new Grid<ProjectSummary>()
         fillProjectsGrid()
         projectGrid.setSelectionMode(Grid.SelectionMode.SINGLE)
         projectGrid.addSelectionListener({
@@ -190,17 +192,31 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void fillProjectsGrid() {
-        projectGrid.addColumn({ it.code})
-                .setCaption("Project Code").setId("ProjectCode").setMaximumWidth(MAX_CODE_COLUMN_WIDTH)
+
+        projectGrid.addColumn({ it.code })
+                .setCaption("Project Code").setId("ProjectCode").setMaximumWidth(
+                MAX_CODE_COLUMN_WIDTH)
         projectGrid.addColumn({ it.title })
                 .setCaption("Project Title").setId("ProjectTitle")
-        projectGrid.addColumn({it.samplesReceived})
+        ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
+            new RelativeCount(it.samplesReceived, it.totalSampleCount )
+        }
+        projectGrid.addColumn(receivedProvider)
                 .setCaption("Samples Received").setId("SamplesReceived")
-        projectGrid.addColumn({it.samplesQcFailed})
+        ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
+            new RelativeCount(it.samplesQcFailed, it.totalSampleCount )
+        }
+        projectGrid.addColumn(failedQcProvider)
                 .setCaption("Samples Failed QC").setId("SamplesFailedQc")
-        projectGrid.addColumn({it.samplesLibraryPrepFinished})
+        ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = {ProjectSummary it ->
+            new RelativeCount(it.samplesLibraryPrepFinished , it.totalSampleCount)
+        }
+        projectGrid.addColumn(libraryPrepProvider)
                 .setCaption("Library Prep Finished").setId("LibraryPrepFinished")
-        projectGrid.addColumn({it.sampleDataAvailable})
+        ValueProvider<ProjectSummary, RelativeCount> dataAvailableProvider = { ProjectSummary it ->
+            new RelativeCount(it.sampleDataAvailable , it.totalSampleCount)
+        }
+        projectGrid.addColumn(dataAvailableProvider)
                 .setCaption("Data Available").setId("SampleDataAvailable")
         setupDataProvider()
         //specify size of grid and layout

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -14,7 +14,7 @@ import life.qbic.portal.sampletracking.resource.status.StatusCount
  *
  * @since 1.0.0
  *
-*/
+ */
 class ProjectOverviewViewModel {
 
     ObservableList projectOverviews = new ObservableList(new ArrayList<ProjectSummary>())
@@ -25,7 +25,7 @@ class ProjectOverviewViewModel {
     @Bindable String generatedManifest
     final Subscriber subscriber
 
-    ProjectOverviewViewModel(ResourceService<Project> projectResourceService, ResourceService<StatusCount> statusCountService, Subscriber subscriber){
+    ProjectOverviewViewModel(ResourceService<Project> projectResourceService, ResourceService<StatusCount> statusCountService, Subscriber subscriber) {
         this.projectResourceService = projectResourceService
         this.statusCountService = statusCountService
         this.subscriber = subscriber
@@ -35,12 +35,14 @@ class ProjectOverviewViewModel {
 
     private void fetchProjectData() {
         projectOverviews.clear()
-        projectResourceService.iterator().each {Project project ->
+        projectResourceService.iterator().each { Project project ->
             addProject(project)
         }
         statusCountService.iterator().each { StatusCount statusCount ->
-            updateSamplesReceived(statusCount.projectCode, statusCount.count)
-            updateSamplesFailedQc(statusCount.projectCode, statusCount.count)
+            updateSamplesReceived(statusCount)
+            updateSamplesFailedQc(statusCount)
+            updateSamplesLibraryPrepFinished(statusCount)
+            updateDataAvailable(statusCount)
         }
     }
 
@@ -48,10 +50,10 @@ class ProjectOverviewViewModel {
         this.projectResourceService.subscribe({ addProject(it) }, Topic.PROJECT_ADDED)
         this.projectResourceService.subscribe({ removeProject(it) }, Topic.PROJECT_REMOVED)
 
-        this.statusCountService.subscribe({updateSamplesReceived(it.projectCode, it.count)}, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
-        this.statusCountService.subscribe({updateSamplesFailedQc(it.projectCode, it.count)}, Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
-        this.statusCountService.subscribe({updateDataAvailable(it.projectCode, it.count)}, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
-        this.statusCountService.subscribe({updateSamplesLibraryPrepFinished(it.projectCode, it.count)}, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
+        this.statusCountService.subscribe({ updateSamplesReceived(it) }, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
+        this.statusCountService.subscribe({ updateSamplesFailedQc(it) }, Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
+        this.statusCountService.subscribe({ updateDataAvailable(it) }, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
+        this.statusCountService.subscribe({ updateSamplesLibraryPrepFinished(it) }, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
     }
 
     private void addProject(Project project) {
@@ -59,26 +61,39 @@ class ProjectOverviewViewModel {
     }
 
     private void removeProject(Project project) {
-        ProjectSummary projectOverview = projectOverviews.collect {it as ProjectSummary}.find { it ->
+        ProjectSummary projectOverview = projectOverviews.collect { it as ProjectSummary }.find { it ->
             (it as ProjectSummary).code == project.projectId.projectCode.toString()
         }
         projectOverviews.remove(projectOverview)
     }
 
-    private void updateSamplesReceived(String projectCode, int sampleCount) {
-        getProjectSummary(projectCode).samplesReceived = sampleCount
+
+    private void updateSamplesReceived(StatusCount statusCount) {
+        ProjectSummary summary = getProjectSummary(statusCount.projectCode)
+        summary.samplesReceived = statusCount.count
+        int totalSampleCount = statusCount.totalSampleCount
+        summary.totalSampleCount = totalSampleCount
     }
 
-    private void updateDataAvailable(String projectCode, int sampleCount) {
-        getProjectSummary(projectCode).sampleDataAvailable = sampleCount
+    private void updateDataAvailable(StatusCount statusCount) {
+        ProjectSummary summary = getProjectSummary(statusCount.projectCode)
+        summary.sampleDataAvailable = statusCount.count
+        int totalSampleCount = statusCount.totalSampleCount
+        summary.totalSampleCount = totalSampleCount
     }
 
-    private void updateSamplesFailedQc(String projectCode, int sampleCount) {
-        getProjectSummary(projectCode).samplesQcFailed = sampleCount
+    private void updateSamplesFailedQc(StatusCount statusCount) {
+        ProjectSummary summary = getProjectSummary(statusCount.projectCode)
+        summary.samplesQcFailed = statusCount.count
+        int totalSampleCount = statusCount.totalSampleCount
+        summary.totalSampleCount = totalSampleCount
     }
 
-    private void updateSamplesLibraryPrepFinished(String projectCode, int sampleCount){
-        getProjectSummary(projectCode).samplesLibraryPrepFinished = sampleCount
+    private void updateSamplesLibraryPrepFinished(StatusCount statusCount) {
+        ProjectSummary summary = getProjectSummary(statusCount.projectCode)
+        summary.samplesLibraryPrepFinished = statusCount.count
+        int totalSampleCount = statusCount.totalSampleCount
+        summary.totalSampleCount = totalSampleCount
     }
 
     /**
@@ -86,15 +101,15 @@ class ProjectOverviewViewModel {
      * @param projectCode The project code specifies a project
      * @return The project summary for the respective code
      */
-    private ProjectSummary getProjectSummary(String projectCode){
-        ProjectSummary projectOverview = projectOverviews.collect {it as ProjectSummary}.find { it ->
+    private ProjectSummary getProjectSummary(String projectCode) {
+        ProjectSummary projectOverview = projectOverviews.collect { it as ProjectSummary }.find { it ->
             (it as ProjectSummary).code == projectCode
         }
         return projectOverview
     }
 
     InputStream getManifestInputStream() {
-        InputStream result =  new ByteArrayInputStream(generatedManifest.getBytes())
+        InputStream result = new ByteArrayInputStream(generatedManifest.getBytes())
         return result
     }
 }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -15,6 +15,7 @@ import life.qbic.datamodel.dtos.projectmanagement.Project
 class ProjectSummary {
     final String code
     final String title
+    int totalSampleCount
     int samplesReceived
     int samplesQcFailed
     int sampleDataAvailable
@@ -27,6 +28,7 @@ class ProjectSummary {
         this.samplesQcFailed = 0
         this.sampleDataAvailable = 0
         this.samplesLibraryPrepFinished = 0
+        this.totalSampleCount = 0
     }
 
     static ProjectSummary of(Project project) {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
@@ -1,0 +1,76 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * <b>A relative count of something.</b>
+ *
+ * <p>This class represents a relative count. It has a value that is a part of a total.</p>
+ *
+ * @since 1.0.0
+ */
+@EqualsAndHashCode
+class RelativeCount implements Comparable<RelativeCount> {
+    final int value
+    final int total
+
+    RelativeCount(int value, int total) {
+        this.value = value
+        this.total = total
+    }
+
+    @Override
+    String toString() {
+        return "$value / $total"
+    }
+    /**
+     * Compares this object with the specified object for order.  Returns a
+     * negative integer, zero, or a positive integer as this object is less
+     * than, equal to, or greater than the specified object.
+     *
+     * <p>The implementor must ensure <tt>sgn(x.compareTo(y)) ==
+     * -sgn(y.compareTo(x))</tt> for all <tt>x</tt> and <tt>y</tt>.  (This
+     * implies that <tt>x.compareTo(y)</tt> must throw an exception if
+     * <tt>y.compareTo(x)</tt> throws an exception.)
+     *
+     * <p>The implementor must also ensure that the relation is transitive:
+     * <tt>(x.compareTo(y)&gt;0 &amp;&amp; y.compareTo(z)&gt;0)</tt> implies
+     * <tt>x.compareTo(z)&gt;0</tt>.
+     *
+     * <p>Finally, the implementor must ensure that <tt>x.compareTo(y)==0</tt>
+     * implies that <tt>sgn(x.compareTo(z)) == sgn(y.compareTo(z))</tt>, for
+     * all <tt>z</tt>.
+     *
+     * <p>It is strongly recommended, but <i>not</i> strictly required that
+     * <tt>(x.compareTo(y)==0) == (x.equals(y))</tt>.  Generally speaking, any
+     * class that implements the <tt>Comparable</tt> interface and violates
+     * this condition should clearly indicate this fact.  The recommended
+     * language is "Note: this class has a natural ordering that is
+     * inconsistent with equals."
+     *
+     * <p>In the foregoing description, the notation
+     * <tt>sgn(</tt><i>expression</i><tt>)</tt> designates the mathematical
+     * <i>signum</i> function, which is defined to return one of <tt>-1</tt>,
+     * <tt>0</tt>, or <tt>1</tt> according to whether the value of
+     * <i>expression</i> is negative, zero or positive.
+     *
+     * @param other the object to be compared.
+     * @return a negative integer, zero, or a positive integer as this object
+     *          is less than, equal to, or greater than the specified object.
+     *
+     * @throws NullPointerException if the specified object is null
+     * @throws ClassCastException if the specified object's type prevents it
+     *         from being compared to this object.
+     */
+    @Override
+    int compareTo(RelativeCount other) {
+        if (this.equals(other))  return 0
+        int valueComparison = this.value.compareTo(other.value)
+        if (valueComparison == 0) {
+            //if the value is equal compare the total
+            return this.total.compareTo(other.total)
+        } else {
+            return valueComparison
+        }
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/State.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/State.groovy
@@ -1,0 +1,33 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+
+/**
+ * <b>The state of a project status.</b>
+ *
+ * <p>A status can have the following states:
+ * <ul>
+ *     <li><b>COMPLETED</b>: When all samples in a project have reached this status and the status is not a failure status.</li>
+ *     <li><b>FAILED</b>: When a status is a failure status and samples are presently in the failed status.</li>
+ *     <li><b>IN_PROGRESS</b>: When not all samples were evaluated for the current status. <b>OR</b>: If the status is a failure status and there are not samples in the status.</li>
+ * </ul>
+ * </p>
+ *
+ * @since 1.0.0
+ */
+enum State {
+    COMPLETED("status-completed"),
+    FAILED("status-failed"),
+    IN_PROGRESS("status-in-progress")
+
+    /**
+     * The class in the CSS that should be assigned to the element.
+     * This does only contain the programmatic part of the css class and does not account for
+     * vaadin prefixes like <code>'.v-grid-cell.'</code>
+     * @since 1.0.0
+     */
+    final String cssClass
+
+    State(String cssClass) {
+        this.cssClass = cssClass
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCount.groovy
@@ -14,10 +14,12 @@ class StatusCount {
     final String projectCode
     final Status status
     final int count
+    final int totalSampleCount
 
-    StatusCount(String projectCode, Status status, int count) {
+    StatusCount(String projectCode, Status status, int count, int totalSampleCount) {
         this.projectCode = Objects.requireNonNull(projectCode, "The project id must not be null.")
         this.status = Objects.requireNonNull(status, "The sample status must not be null.")
         this.count = Objects.requireNonNull(count, "The count must not be null.")
+        this.totalSampleCount = Objects.requireNonNull(totalSampleCount, "The total number of samples must not be null")
     }
 }

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -39,6 +39,18 @@
   /* Include all the styles from the valo theme */
   @include valo;
 
+  .v-grid-cell.status-completed {
+    background-color: #b3e2cd;
+  }
+
+  .v-grid-cell.status-in-progress {
+    background-color: #cbd5e8;
+  }
+
+  .v-grid-cell.status-failed {
+    background-color: #fdcdac;
+  }
+
   /* Insert your theme rules here */
   .portlet-footer {
     font-size: 9pt;

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -40,15 +40,15 @@
   @include valo;
 
   .v-grid-cell.status-completed {
-    background-color: #b3e2cd;
+    background-color: #31c44a;
   }
 
   .v-grid-cell.status-in-progress {
-    background-color: #cbd5e8;
+    background-color: #EDEDED;
   }
 
   .v-grid-cell.status-failed {
-    background-color: #fdcdac;
+    background-color: #fc4c4c;
   }
 
   /* Insert your theme rules here */

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -41,14 +41,17 @@
 
   .v-grid-cell.status-completed {
     background-color: #31c44a;
+    text-align: center;
   }
 
   .v-grid-cell.status-in-progress {
     background-color: #EDEDED;
+    text-align: center;
   }
 
   .v-grid-cell.status-failed {
     background-color: #fc4c4c;
+    text-align: center;
   }
 
   /* Insert your theme rules here */

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCountSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCountSpec.groovy
@@ -1,0 +1,101 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+
+import spock.lang.Specification
+
+/**
+ * <b>Tests for equals and compareTo methods</b>
+ *
+ * @since 1.0.0
+ */
+class RelativeCountSpec extends Specification {
+
+    def "Equals is false for different relative counts"() {
+        given: "Two ids with different content"
+        def relativeCountA = new RelativeCount(3, 42)
+        def relativeCountB = new RelativeCount(value, total)
+
+        expect: "them not to be equal"
+        relativeCountA != relativeCountB
+
+        where: "all properties are different"
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "Equals is true for equal RelativeCounts"() {
+        given: "Two ids with different content"
+        def relativeCountA = new RelativeCount(value, total)
+        def relativeCountB = new RelativeCount(value, total)
+
+        expect: "them not to be equal"
+        relativeCountA == relativeCountB
+
+        where: "all properties are different"
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "compareTo is transitive: (#x > #y and #y > #z) then #x > #z"() {
+        when: "x.compareTo(y) > 0 && y.compareTo(z) > 0"
+        assert x.compareTo(y) > 0 && y.compareTo(z) > 0
+        then: "x.compareTo(z) > 0"
+        x.compareTo(z) > 0
+        where: "x, y and z are as follows"
+        x | y | z
+        new RelativeCount(2,2) | new RelativeCount(1,2) | new RelativeCount(0,2)
+        new RelativeCount(0,4) | new RelativeCount(0,3) | new RelativeCount(0,2)
+        new RelativeCount(3,3) | new RelativeCount(2,4) | new RelativeCount(1,5)
+    }
+
+
+    def "compareTo is symmetric: sgn(x.compareTo(y)) = -sgn(y.compareTo(x)) for x=#x and y=#y"() {
+        expect: "sgn(#x.compareTo(#y)) = -sgn(#y.compareTo(#x))"
+        Integer.signum(x.compareTo(y)) == -Integer.signum(y.compareTo(x))
+        where:
+        x | y
+        new RelativeCount(2,2) | new RelativeCount(2,2)
+        new RelativeCount(2,2) | new RelativeCount(1,2)
+        new RelativeCount(2,2) | new RelativeCount(3,2)
+    }
+
+    def "compareTo is reflexive: equals itself"() {
+        given:
+        RelativeCount relativeCount = new RelativeCount(value, total)
+        expect:
+        relativeCount.equals(relativeCount)
+        where:
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "compareTo returns 0 for equal objects"() {
+        given:
+        RelativeCount relativeCount = new RelativeCount(1,4)
+        expect:
+        relativeCount.equals(relativeCount)
+        relativeCount.compareTo(relativeCount) == 0
+    }
+
+    def "compareTo does not returns 0 for unequal objects"() {
+        given:
+        RelativeCount relativeCountA = new RelativeCount(1,4)
+        RelativeCount relativeCount2 = new RelativeCount(4,99)
+
+        expect:
+        !relativeCountA.equals(relativeCount2)
+        relativeCountA.compareTo(relativeCount2) != 0
+    }
+
+    def "compareTo #x <=> #y = #expectedResult"() {
+        when:
+        int result = x <=> y
+        then:
+        result == expectedResult
+
+        where:
+        x | y | expectedResult
+        new RelativeCount(2,2) | new RelativeCount(2,2) | 0
+        new RelativeCount(2,2) | new RelativeCount(1,2) | 1
+        new RelativeCount(2,3) | new RelativeCount(3,3) | -1
+        new RelativeCount(1,2) | new RelativeCount(1,1) | 1
+        new RelativeCount(1,2) | new RelativeCount(1,3) | -1
+    }
+}

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
@@ -100,7 +100,8 @@ class StatusCountResourceServiceSpec extends Specification {
     static StatusCount generateRandomStatusCount(Status status) {
         Random random = new Random()
         int count = random.nextInt()
+        int total = count + count
         String projectName = "TEST_NAME"
-        return new StatusCount(projectName, status, count)
+        return new StatusCount(projectName, status, count, total)
     }
 }

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountSpec.groovy
@@ -11,29 +11,30 @@ class StatusCountSpec extends Specification {
 
     def "equal StatusCount objects are equal"() {
         given: "two status counts with the same information"
-        StatusCount statusCount1 = new StatusCount(projectCode, status, count)
-        StatusCount statusCount2 = new StatusCount(projectCode, status, count)
+        StatusCount statusCount1 = new StatusCount(projectCode, status, count, total)
+        StatusCount statusCount2 = new StatusCount(projectCode, status, count, total)
 
         expect: "the two are equal"
         statusCount1 == statusCount2
 
         where:
-        projectCode | status | count
-        "TEST" | Status.SAMPLE_RECEIVED | 1
+        projectCode | status | count | total
+        "TEST" | Status.SAMPLE_RECEIVED | 1 | 6
     }
 
     def "different StatusCount objects are not equal"() {
         given: "two status counts with the same information"
-        StatusCount statusCount1 = new StatusCount("TEST", Status.SAMPLE_RECEIVED, 0)
-        StatusCount statusCount2 = new StatusCount(projectCode, status, count)
+        StatusCount statusCount1 = new StatusCount("TEST", Status.SAMPLE_RECEIVED, 0, 8)
+        StatusCount statusCount2 = new StatusCount(projectCode, status, count, total)
 
         expect: "the two are not equal"
         statusCount1 != statusCount2
 
         where:
-        projectCode | status | count
-        "TEST" | Status.SAMPLE_RECEIVED | 1
-        "TEST" | Status.DATA_AVAILABLE | 0
-        "TEST_2" | Status.SAMPLE_RECEIVED | 0
+        projectCode | status | count | total
+        "TEST_2" | Status.SAMPLE_RECEIVED | 0 | 8
+        "TEST" | Status.DATA_AVAILABLE | 0 | 8
+        "TEST" | Status.SAMPLE_RECEIVED | 99 | 8
+        "TEST" | Status.SAMPLE_RECEIVED | 0 | 99
     }
 }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/count/CountSamplesInput.groovy
@@ -11,41 +11,12 @@ interface CountSamplesInput {
 
     /**
      * This method calls the output interface with the number of samples in the project
-     * and the number of samples that have been received in the sequencing lab.
+     * and the number of samples are within (or have passed) a specific status.
      * In case of failure the output interface failure method is called.
      *
      * @param projectCode a code specifying the samples that should be considered
      * @since 1.0.0
      */
-    void countReceivedSamples(String projectCode)
+    void countSamplesPerStatus(String projectCode)
 
-    /**
-     * This method calls the output interface with the number of samples in the project
-     * and the number of samples that have failed quality control.
-     * In case of failure the output interface failure method is called.
-     *
-     * @param projectCode a code specifying the samples that should be considered
-     * @since 1.0.0
-     */
-    void countQcFailedSamples(String projectCode)
-
-    /**
-     * This method calls the output interface with the number of samples in the project
-     * and the number of samples for which data is available.
-     * In case of failure the output interface failure method is called.
-     *
-     * @param projectCode A code specifying the samples that should be considered
-     * @since 1.0.0
-     */
-    void countAvailableDataSamples(String projectCode)
-
-    /**
-     * This method calls the output interface with the number of samples in the project
-     * and the number of samples for which the library prep is finished.
-     * In case of failure the output interface failure method is called.
-     *
-     * @param projectCode A code specifying the samples that should be considered
-     * @since 1.0.0
-     */
-    void countLibraryPrepFinishedSamples(String projectCode)
 }

--- a/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/count/CountSamplesSpec.groovy
+++ b/sample-tracking-status-overview-domain/src/test/groovy/life/qbic/business/samples/count/CountSamplesSpec.groovy
@@ -20,7 +20,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"a successful message is send"
         1 * output.countedReceivedSamples(projectCode, _ as Integer, _ as Integer)
         0 * output.failedExecution(_ as String)
@@ -35,7 +35,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"the correct amounts of samples are returned"
         1 * output.countedReceivedSamples(projectCode, 3, 2)
         0 * output.failedExecution(_ as String)
@@ -50,7 +50,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"the correct amounts of samples are returned"
         1 * output.countedReceivedSamples(projectCode, 4, 3)
         0 * output.failedExecution(_ as String)
@@ -65,7 +65,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"the correct amounts of samples are returned"
         1 * output.countedReceivedSamples(projectCode, 4, 2)
         0 * output.failedExecution(_ as String)
@@ -81,7 +81,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"a failure message is send"
         1 * output.failedExecution(_)
         0 * output.countedReceivedSamples(_)
@@ -98,7 +98,7 @@ class CountSamplesSpec extends Specification {
         CountSamples countSamples = new CountSamples(dataSource, output)
 
         when:"the use case is run"
-        countSamples.countReceivedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
 
         then:"a failure message is send"
         1 * output.failedExecution(_)
@@ -113,7 +113,7 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countQcFailedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"a successful message is send"
         1 * output.countedFailedQcSamples(projectCode, 0, 0)
         0 * output.failedExecution(_ as String)
@@ -128,12 +128,11 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countQcFailedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"the correct amounts of samples are returned"
         1 * output.countedFailedQcSamples(projectCode, 3, 2)
         0 * output.failedExecution(_ as String)
     }
-
 
     def "unsuccessful execution of counting failed qc samples leads to failure notifications"() {
         given:
@@ -145,12 +144,13 @@ class CountSamplesSpec extends Specification {
         CountSamplesOutput output = Mock()
         CountSamples countSamples = new CountSamples(dataSource, output)
         when:"the use case is run"
-        countSamples.countQcFailedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:"a failure message is send"
         1 * output.failedExecution(_)
         0 * output.countedFailedQcSamples(_)
     }
-def "countFailedQcSamples does not count samples with status #status"() {
+
+    def "countFailedQcSamples does not count samples with status #status"() {
         given: "a project code"
         String projectCode = "QABCD"
         and: "a datasource stub returning one sample of the status"
@@ -161,7 +161,7 @@ def "countFailedQcSamples does not count samples with status #status"() {
         CountSamplesOutput output = Mock()
         when:
         CountSamples countSamples = new CountSamples(dataSource, output)
-        countSamples.countQcFailedSamples(projectCode)
+        countSamples.countSamplesPerStatus(projectCode)
         then:
         0 * output.failedExecution(_)
         1 * output.countedFailedQcSamples(projectCode, totalNumber, 0)


### PR DESCRIPTION
This PR introduces the feature of indicating the project status by color. 

- [X] Extend the project summary (#101)
- [x] Show total sample count in view (#104)
- [x] Set default color to grey (#102)
- [x] Completed statuses are shown in green (#102)
- [x] Failing QC is indicated in red (#102)