### PR TITLE
Introduce RelativeCount

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
+import com.vaadin.data.ValueProvider
 import com.vaadin.data.provider.ListDataProvider
 import com.vaadin.event.selection.SingleSelectionEvent
 import com.vaadin.icons.VaadinIcons
@@ -12,9 +13,10 @@ import com.vaadin.ui.themes.ValoTheme
 import life.qbic.portal.sampletracking.Constants
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
 import life.qbic.portal.sampletracking.components.projectoverview.download.DownloadProjectController
-import life.qbic.portal.sampletracking.components.projectoverview.subscribe.SubscribeProjectController
-import life.qbic.portal.sampletracking.components.projectoverview.samplelist.ProjectOverviewController
 import life.qbic.portal.sampletracking.components.projectoverview.samplelist.FailedQCSamplesView
+import life.qbic.portal.sampletracking.components.projectoverview.samplelist.ProjectOverviewController
+import life.qbic.portal.sampletracking.components.projectoverview.statusdisplay.RelativeCount
+import life.qbic.portal.sampletracking.components.projectoverview.subscribe.SubscribeProjectController
 
 /**
  * <b>This class generates the layout for the ProductOverview use case</b>
@@ -150,7 +152,7 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void setupProjects() {
-        projectGrid = new Grid<>()
+        projectGrid = new Grid<ProjectSummary>()
         fillProjectsGrid()
         projectGrid.setSelectionMode(Grid.SelectionMode.SINGLE)
         projectGrid.addSelectionListener({
@@ -190,17 +192,31 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void fillProjectsGrid() {
-        projectGrid.addColumn({ it.code})
-                .setCaption("Project Code").setId("ProjectCode").setMaximumWidth(MAX_CODE_COLUMN_WIDTH)
+
+        projectGrid.addColumn({ it.code })
+                .setCaption("Project Code").setId("ProjectCode").setMaximumWidth(
+                MAX_CODE_COLUMN_WIDTH)
         projectGrid.addColumn({ it.title })
                 .setCaption("Project Title").setId("ProjectTitle")
-        projectGrid.addColumn({it.samplesReceived})
+        ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
+            new RelativeCount(it.samplesReceived, it.totalSampleCount )
+        }
+        projectGrid.addColumn(receivedProvider)
                 .setCaption("Samples Received").setId("SamplesReceived")
-        projectGrid.addColumn({it.samplesQcFailed})
+        ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
+            new RelativeCount(it.samplesQcFailed, it.totalSampleCount )
+        }
+        projectGrid.addColumn(failedQcProvider)
                 .setCaption("Samples Failed QC").setId("SamplesFailedQc")
-        projectGrid.addColumn({it.samplesLibraryPrepFinished})
+        ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = {ProjectSummary it ->
+            new RelativeCount(it.samplesLibraryPrepFinished , it.totalSampleCount)
+        }
+        projectGrid.addColumn(libraryPrepProvider)
                 .setCaption("Library Prep Finished").setId("LibraryPrepFinished")
-        projectGrid.addColumn({it.sampleDataAvailable})
+        ValueProvider<ProjectSummary, RelativeCount> dataAvailableProvider = { ProjectSummary it ->
+            new RelativeCount(it.sampleDataAvailable , it.totalSampleCount)
+        }
+        projectGrid.addColumn(dataAvailableProvider)
                 .setCaption("Data Available").setId("SampleDataAvailable")
         setupDataProvider()
         //specify size of grid and layout

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
@@ -30,7 +30,7 @@ class RelativeCount implements Comparable<RelativeCount> {
      *
      * <p>The implementor must ensure <tt>sgn(x.compareTo(y)) ==
      * -sgn(y.compareTo(x))</tt> for all <tt>x</tt> and <tt>y</tt>.  (This
-     * implies that <tt>x.compareTo(y)</tt> must throw an exception iff
+     * implies that <tt>x.compareTo(y)</tt> must throw an exception if
      * <tt>y.compareTo(x)</tt> throws an exception.)
      *
      * <p>The implementor must also ensure that the relation is transitive:

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCount.groovy
@@ -1,0 +1,76 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * <b>A relative count of something.</b>
+ *
+ * <p>This class represents a relative count. It has a value that is a part of a total.</p>
+ *
+ * @since 1.0.0
+ */
+@EqualsAndHashCode
+class RelativeCount implements Comparable<RelativeCount> {
+    final int value
+    final int total
+
+    RelativeCount(int value, int total) {
+        this.value = value
+        this.total = total
+    }
+
+    @Override
+    String toString() {
+        return "$value / $total"
+    }
+    /**
+     * Compares this object with the specified object for order.  Returns a
+     * negative integer, zero, or a positive integer as this object is less
+     * than, equal to, or greater than the specified object.
+     *
+     * <p>The implementor must ensure <tt>sgn(x.compareTo(y)) ==
+     * -sgn(y.compareTo(x))</tt> for all <tt>x</tt> and <tt>y</tt>.  (This
+     * implies that <tt>x.compareTo(y)</tt> must throw an exception iff
+     * <tt>y.compareTo(x)</tt> throws an exception.)
+     *
+     * <p>The implementor must also ensure that the relation is transitive:
+     * <tt>(x.compareTo(y)&gt;0 &amp;&amp; y.compareTo(z)&gt;0)</tt> implies
+     * <tt>x.compareTo(z)&gt;0</tt>.
+     *
+     * <p>Finally, the implementor must ensure that <tt>x.compareTo(y)==0</tt>
+     * implies that <tt>sgn(x.compareTo(z)) == sgn(y.compareTo(z))</tt>, for
+     * all <tt>z</tt>.
+     *
+     * <p>It is strongly recommended, but <i>not</i> strictly required that
+     * <tt>(x.compareTo(y)==0) == (x.equals(y))</tt>.  Generally speaking, any
+     * class that implements the <tt>Comparable</tt> interface and violates
+     * this condition should clearly indicate this fact.  The recommended
+     * language is "Note: this class has a natural ordering that is
+     * inconsistent with equals."
+     *
+     * <p>In the foregoing description, the notation
+     * <tt>sgn(</tt><i>expression</i><tt>)</tt> designates the mathematical
+     * <i>signum</i> function, which is defined to return one of <tt>-1</tt>,
+     * <tt>0</tt>, or <tt>1</tt> according to whether the value of
+     * <i>expression</i> is negative, zero or positive.
+     *
+     * @param other the object to be compared.
+     * @return a negative integer, zero, or a positive integer as this object
+     *          is less than, equal to, or greater than the specified object.
+     *
+     * @throws NullPointerException if the specified object is null
+     * @throws ClassCastException if the specified object's type prevents it
+     *         from being compared to this object.
+     */
+    @Override
+    int compareTo(RelativeCount other) {
+        if (this.equals(other))  return 0
+        int valueComparison = this.value.compareTo(other.value)
+        if (valueComparison == 0) {
+            //if the value is equal compare the total
+            return this.total.compareTo(other.total)
+        } else {
+            return valueComparison
+        }
+    }
+}

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCountSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/components/projectoverview/statusdisplay/RelativeCountSpec.groovy
@@ -1,0 +1,101 @@
+package life.qbic.portal.sampletracking.components.projectoverview.statusdisplay
+
+
+import spock.lang.Specification
+
+/**
+ * <b>Tests for equals and compareTo methods</b>
+ *
+ * @since 1.0.0
+ */
+class RelativeCountSpec extends Specification {
+
+    def "Equals is false for different relative counts"() {
+        given: "Two ids with different content"
+        def relativeCountA = new RelativeCount(3, 42)
+        def relativeCountB = new RelativeCount(value, total)
+
+        expect: "them not to be equal"
+        relativeCountA != relativeCountB
+
+        where: "all properties are different"
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "Equals is true for equal RelativeCounts"() {
+        given: "Two ids with different content"
+        def relativeCountA = new RelativeCount(value, total)
+        def relativeCountB = new RelativeCount(value, total)
+
+        expect: "them not to be equal"
+        relativeCountA == relativeCountB
+
+        where: "all properties are different"
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "compareTo is transitive: (#x > #y and #y > #z) then #x > #z"() {
+        when: "x.compareTo(y) > 0 && y.compareTo(z) > 0"
+        assert x.compareTo(y) > 0 && y.compareTo(z) > 0
+        then: "x.compareTo(z) > 0"
+        x.compareTo(z) > 0
+        where: "x, y and z are as follows"
+        x | y | z
+        new RelativeCount(2,2) | new RelativeCount(1,2) | new RelativeCount(0,2)
+        new RelativeCount(0,4) | new RelativeCount(0,3) | new RelativeCount(0,2)
+        new RelativeCount(3,3) | new RelativeCount(2,4) | new RelativeCount(1,5)
+    }
+
+
+    def "compareTo is symmetric: sgn(x.compareTo(y)) = -sgn(y.compareTo(x)) for x=#x and y=#y"() {
+        expect: "sgn(#x.compareTo(#y)) = -sgn(#y.compareTo(#x))"
+        Integer.signum(x.compareTo(y)) == -Integer.signum(y.compareTo(x))
+        where:
+        x | y
+        new RelativeCount(2,2) | new RelativeCount(2,2)
+        new RelativeCount(2,2) | new RelativeCount(1,2)
+        new RelativeCount(2,2) | new RelativeCount(3,2)
+    }
+
+    def "compareTo is reflexive: equals itself"() {
+        given:
+        RelativeCount relativeCount = new RelativeCount(value, total)
+        expect:
+        relativeCount.equals(relativeCount)
+        where:
+        [value, total] << [[0, 4, 33, 9, 7, 100], [100, 333, 124]].combinations()
+    }
+
+    def "compareTo returns 0 for equal objects"() {
+        given:
+        RelativeCount relativeCount = new RelativeCount(1,4)
+        expect:
+        relativeCount.equals(relativeCount)
+        relativeCount.compareTo(relativeCount) == 0
+    }
+
+    def "compareTo does not returns 0 for unequal objects"() {
+        given:
+        RelativeCount relativeCountA = new RelativeCount(1,4)
+        RelativeCount relativeCount2 = new RelativeCount(4,99)
+
+        expect:
+        !relativeCountA.equals(relativeCount2)
+        relativeCountA.compareTo(relativeCount2) != 0
+    }
+
+    def "compareTo #x <=> #y = #expectedResult"() {
+        when:
+        int result = x <=> y
+        then:
+        result == expectedResult
+
+        where:
+        x | y | expectedResult
+        new RelativeCount(2,2) | new RelativeCount(2,2) | 0
+        new RelativeCount(2,2) | new RelativeCount(1,2) | 1
+        new RelativeCount(2,3) | new RelativeCount(3,3) | -1
+        new RelativeCount(1,2) | new RelativeCount(1,1) | 1
+        new RelativeCount(1,2) | new RelativeCount(1,3) | -1
+    }
+}


### PR DESCRIPTION
Introduces relative sample counts to the project grid.
This object is comparable which makes the column sortable. The comparison is done first by the number of samples and then by the total number of possible samples in this status.
The rendering is done via the `toString()` method which provides a representation like `5 / 33`.

Resolve #65 