### PR TITLE
Extend sample count with failing and passing counts

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/communication/Topic.groovy
@@ -13,6 +13,7 @@ enum Topic {
     NOTIFICATION_SUCCESS("Success notification"),
     NOTIFICATION_INFO("Information notification"),
     SAMPLE_RECEIVED_COUNT_UPDATE("The count of received samples was updated"),
+    SAMPLE_PASSED_QC_COUNT_UPDATE("The count of samples passing QC was updated"),
     SAMPLE_FAILED_QC_COUNT_UPDATE("The count of samples failing QC was updated"),
     SAMPLE_DATA_AVAILABLE_COUNT_UPDATE("The count of available samples data was updated"),
     SAMPLE_LIBRARY_PREP_FINISHED("The count of samples with finished library prep was updated")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -262,8 +262,9 @@ class ProjectOverviewView extends VerticalLayout{
 
 
     private void tryToDownloadManifest() {
+        Optional<ProjectSummary> selectedSummary = Optional.empty()
         try {
-            Optional<ProjectSummary> selectedSummary = Optional.ofNullable(viewModel.selectedProject)
+            selectedSummary = Optional.ofNullable(viewModel.selectedProject)
             selectedSummary.filter({it.sampleDataAvailable.passingSamples > 0 }).ifPresent({
                 String projectCode = it.getCode()
                 downloadProjectController.downloadProject(projectCode)
@@ -273,6 +274,7 @@ class ProjectOverviewView extends VerticalLayout{
             log.error "Manifest Download failed due to: ${illegalArgument.getMessage()}"
         } catch (Exception exception) {
             notificationService.publishFailure("Manifest Download failed for unknown reasons. ${Constants.CONTACT_HELPDESK}")
+            log.error "An error occured whily trying to download ${selectedSummary}"
             log.error "Manifest Download failed due to: ${exception.getMessage()}"
         }
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -263,7 +263,8 @@ class ProjectOverviewView extends VerticalLayout{
 
     private void tryToDownloadManifest() {
         try {
-            Optional.ofNullable(viewModel.selectedProject).filter({it.sampleDataAvailable.passingSamples > 0 }).ifPresent({
+            Optional<ProjectSummary> selectedSummary = Optional.ofNullable(viewModel.selectedProject)
+            selectedSummary.filter({it.sampleDataAvailable.passingSamples > 0 }).ifPresent({
                 String projectCode = it.getCode()
                 downloadProjectController.downloadProject(projectCode)
             })

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -270,7 +270,8 @@ class ProjectOverviewView extends VerticalLayout{
                 downloadProjectController.downloadProject(projectCode)
             })
         } catch (IllegalArgumentException illegalArgument) {
-            notificationService.publishFailure("Manifest Download failed for project ${viewModel.selectedProject.getCode()}. ${Constants.CONTACT_HELPDESK}")
+            String projectCode = selectedSummary.map(ProjectSummary::getCode).orElse("No project selected")
+            notificationService.publishFailure("Manifest Download failed for project ${projectCode}. ${Constants.CONTACT_HELPDESK}")
             log.error "Manifest Download failed due to: ${illegalArgument.getMessage()}"
         } catch (Exception exception) {
             notificationService.publishFailure("Manifest Download failed for unknown reasons. ${Constants.CONTACT_HELPDESK}")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -89,7 +89,7 @@ class ProjectOverviewView extends VerticalLayout{
         projectGrid.addSelectionListener({
             failedQCSamplesView.setVisible(false)
 
-            if(viewModel.selectedProject && viewModel.selectedProject.samplesQcPassed.failingSamples > 0){
+            if(viewModel.selectedProject && viewModel.selectedProject.samplesQc.failingSamples > 0){
                 detailsButton.setEnabled(true)
             }else{
                 detailsButton.setEnabled(false)
@@ -213,7 +213,7 @@ class ProjectOverviewView extends VerticalLayout{
                 .setCaption("Project Code").setId("ProjectCode").setMaximumWidth(
                 MAX_CODE_COLUMN_WIDTH)
         projectGrid.addColumn({ it.title })
-                .setCaption("Project Title").setId("ProjectTitle")
+                .setCaption("Project Title").setId("ProjectTitle").setDescriptionGenerator({it.title})
 
         ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
             new RelativeCount(it.samplesReceived.passingSamples, it.totalSampleCount )
@@ -222,7 +222,7 @@ class ProjectOverviewView extends VerticalLayout{
                 .setCaption("Samples Received").setId("SamplesReceived")
 
         ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
-            new RelativeCount(it.samplesQcPassed.passingSamples, it.totalSampleCount )
+            new RelativeCount(it.samplesQc.passingSamples, it.totalSampleCount )
         }
         projectGrid.addColumn(failedQcProvider)
                 .setCaption("Samples Passed QC").setId("SamplesPassedQc").setStyleGenerator({getStyleForFailureColumn(it, failedQcProvider)})
@@ -243,7 +243,7 @@ class ProjectOverviewView extends VerticalLayout{
         //specify size of grid and layout
         projectGrid.setWidthFull()
         projectGrid.getColumn("ProjectTitle")
-                .setMinimumWidth(200)
+                .setMaximumWidth(800)
         projectGrid.getColumn("SamplesReceived")
                 .setMaximumWidth(MAX_STATUS_COLUMN_WIDTH).setExpandRatio(1)
         projectGrid.getColumn("SamplesPassedQc")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -268,7 +268,7 @@ class ProjectOverviewView extends VerticalLayout{
                 downloadProjectController.downloadProject(projectCode)
             })
         } catch (IllegalArgumentException illegalArgument) {
-            notificationService.publishFailure("Manifest Download failed for unknown reasons. ${Constants.CONTACT_HELPDESK}")
+            notificationService.publishFailure("Manifest Download failed for project ${viewModel.selectedProject.getCode()}. ${Constants.CONTACT_HELPDESK}")
             log.error "Manifest Download failed due to: ${illegalArgument.getMessage()}"
         } catch (Exception exception) {
             notificationService.publishFailure("Manifest Download failed for unknown reasons. ${Constants.CONTACT_HELPDESK}")

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -212,26 +212,31 @@ class ProjectOverviewView extends VerticalLayout{
                 MAX_CODE_COLUMN_WIDTH)
         projectGrid.addColumn({ it.title })
                 .setCaption("Project Title").setId("ProjectTitle")
+
         ValueProvider<ProjectSummary, RelativeCount> receivedProvider = { ProjectSummary it ->
-            new RelativeCount(it.samplesReceived, it.totalSampleCount )
+            new RelativeCount(it.samplesReceived.passingSamples, it.totalSampleCount )
         }
         projectGrid.addColumn(receivedProvider).setStyleGenerator({getStyleForColumn(it, receivedProvider)})
                 .setCaption("Samples Received").setId("SamplesReceived")
+
         ValueProvider<ProjectSummary, RelativeCount> failedQcProvider = { ProjectSummary it ->
-            new RelativeCount(it.samplesQcFailed, it.totalSampleCount )
+            new RelativeCount(it.samplesQcPassed.passingSamples, it.totalSampleCount )
         }
         projectGrid.addColumn(failedQcProvider)
-                .setCaption("Samples Failed QC").setId("SamplesFailedQc").setStyleGenerator({getStyleForFailureColumn(it, failedQcProvider)})
+                .setCaption("Samples Passed QC").setId("SamplesPassedQc").setStyleGenerator({getStyleForFailureColumn(it, failedQcProvider)})
+
         ValueProvider<ProjectSummary, RelativeCount> libraryPrepProvider = {ProjectSummary it ->
-            new RelativeCount(it.samplesLibraryPrepFinished , it.totalSampleCount)
+            new RelativeCount(it.samplesLibraryPrepFinished.passingSamples , it.totalSampleCount)
         }
         projectGrid.addColumn(libraryPrepProvider)
                 .setCaption("Library Prep Finished").setId("LibraryPrepFinished").setStyleGenerator({getStyleForColumn(it, libraryPrepProvider)})
+
         ValueProvider<ProjectSummary, RelativeCount> dataAvailableProvider = { ProjectSummary it ->
-            new RelativeCount(it.sampleDataAvailable , it.totalSampleCount)
+            new RelativeCount(it.sampleDataAvailable.passingSamples , it.totalSampleCount)
         }
         projectGrid.addColumn(dataAvailableProvider).setStyleGenerator({getStyleForColumn(it, dataAvailableProvider)})
                 .setCaption("Data Available").setId("SampleDataAvailable")
+
         setupDataProvider()
         //specify size of grid and layout
         projectGrid.setWidthFull()
@@ -239,7 +244,7 @@ class ProjectOverviewView extends VerticalLayout{
                 .setMinimumWidth(200)
         projectGrid.getColumn("SamplesReceived")
                 .setMaximumWidth(MAX_STATUS_COLUMN_WIDTH).setExpandRatio(1)
-        projectGrid.getColumn("SamplesFailedQc")
+        projectGrid.getColumn("SamplesPassedQc")
                 .setMaximumWidth(MAX_STATUS_COLUMN_WIDTH).setExpandRatio(1)
         projectGrid.getColumn("LibraryPrepFinished")
                 .setMaximumWidth(MAX_STATUS_COLUMN_WIDTH).setExpandRatio(1)

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -67,31 +67,30 @@ class ProjectOverviewViewModel {
         projectOverviews.remove(projectOverview)
     }
 
-
     private void updateSamplesReceived(StatusCount statusCount) {
         ProjectSummary summary = getProjectSummary(statusCount.projectCode)
-        summary.samplesReceived = statusCount.count
+        summary.samplesReceived.passingSamples = statusCount.count
         int totalSampleCount = statusCount.totalSampleCount
         summary.totalSampleCount = totalSampleCount
     }
 
     private void updateDataAvailable(StatusCount statusCount) {
         ProjectSummary summary = getProjectSummary(statusCount.projectCode)
-        summary.sampleDataAvailable = statusCount.count
+        summary.sampleDataAvailable.passingSamples = statusCount.count
         int totalSampleCount = statusCount.totalSampleCount
         summary.totalSampleCount = totalSampleCount
     }
 
     private void updateSamplesFailedQc(StatusCount statusCount) {
         ProjectSummary summary = getProjectSummary(statusCount.projectCode)
-        summary.samplesQcFailed = statusCount.count
+        summary.samplesQcPassed.failingSamples = statusCount.count
         int totalSampleCount = statusCount.totalSampleCount
         summary.totalSampleCount = totalSampleCount
     }
 
     private void updateSamplesLibraryPrepFinished(StatusCount statusCount) {
         ProjectSummary summary = getProjectSummary(statusCount.projectCode)
-        summary.samplesLibraryPrepFinished = statusCount.count
+        summary.samplesLibraryPrepFinished.passingSamples = statusCount.count
         int totalSampleCount = statusCount.totalSampleCount
         summary.totalSampleCount = totalSampleCount
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewViewModel.groovy
@@ -41,6 +41,7 @@ class ProjectOverviewViewModel {
         statusCountService.iterator().each { StatusCount statusCount ->
             updateSamplesReceived(statusCount)
             updateSamplesFailedQc(statusCount)
+
             updateSamplesLibraryPrepFinished(statusCount)
             updateDataAvailable(statusCount)
         }
@@ -51,6 +52,7 @@ class ProjectOverviewViewModel {
         this.projectResourceService.subscribe({ removeProject(it) }, Topic.PROJECT_REMOVED)
 
         this.statusCountService.subscribe({ updateSamplesReceived(it) }, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
+        this.statusCountService.subscribe({ updateSamplesPassedQc(it) }, Topic.SAMPLE_PASSED_QC_COUNT_UPDATE)
         this.statusCountService.subscribe({ updateSamplesFailedQc(it) }, Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
         this.statusCountService.subscribe({ updateDataAvailable(it) }, Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
         this.statusCountService.subscribe({ updateSamplesLibraryPrepFinished(it) }, Topic.SAMPLE_LIBRARY_PREP_FINISHED)
@@ -81,9 +83,16 @@ class ProjectOverviewViewModel {
         summary.totalSampleCount = totalSampleCount
     }
 
+    private void updateSamplesPassedQc(StatusCount statusCount) {
+        ProjectSummary summary = getProjectSummary(statusCount.projectCode)
+        summary.samplesQc.passingSamples = statusCount.count
+        int totalSampleCount = statusCount.totalSampleCount
+        summary.totalSampleCount = totalSampleCount
+    }
+
     private void updateSamplesFailedQc(StatusCount statusCount) {
         ProjectSummary summary = getProjectSummary(statusCount.projectCode)
-        summary.samplesQcPassed.failingSamples = statusCount.count
+        summary.samplesQc.failingSamples = statusCount.count
         int totalSampleCount = statusCount.totalSampleCount
         summary.totalSampleCount = totalSampleCount
     }

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -17,7 +17,7 @@ class ProjectSummary {
     final String title
     int totalSampleCount
     SampleCount samplesReceived
-    SampleCount samplesQcPassed
+    SampleCount samplesQc
     SampleCount samplesLibraryPrepFinished
     SampleCount sampleDataAvailable
 
@@ -25,7 +25,7 @@ class ProjectSummary {
         this.code = code
         this.title = title
         this.samplesReceived = new SampleCount(0,0)
-        this.samplesQcPassed = new SampleCount(0,0)
+        this.samplesQc = new SampleCount(0,0)
         this.samplesLibraryPrepFinished = new SampleCount(0,0)
         this.sampleDataAvailable = new SampleCount(0,0)
         this.totalSampleCount = 0

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -17,6 +17,7 @@ class ProjectSummary {
     final String title
     int totalSampleCount
     int samplesReceived
+    int samplesQcPassed
     int samplesQcFailed
     int sampleDataAvailable
     int samplesLibraryPrepFinished
@@ -25,6 +26,7 @@ class ProjectSummary {
         this.code = code
         this.title = title
         this.samplesReceived = 0
+        this.samplesQcPassed = 0
         this.samplesQcFailed = 0
         this.sampleDataAvailable = 0
         this.samplesLibraryPrepFinished = 0

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -16,20 +16,20 @@ class ProjectSummary {
     final String code
     final String title
     int totalSampleCount
-    int samplesReceived
-    int samplesQcPassed
-    int samplesQcFailed
-    int sampleDataAvailable
-    int samplesLibraryPrepFinished
+    SampleCount samplesReceived
+    SampleCount samplesQcPassed
+    SampleCount samplesQcFailed
+    SampleCount samplesLibraryPrepFinished
+    SampleCount sampleDataAvailable
 
     ProjectSummary(String code, String title) {
         this.code = code
         this.title = title
-        this.samplesReceived = 0
-        this.samplesQcPassed = 0
-        this.samplesQcFailed = 0
-        this.sampleDataAvailable = 0
-        this.samplesLibraryPrepFinished = 0
+        this.samplesReceived = new SampleCount(0,0)
+        this.samplesQcPassed = new SampleCount(0,0)
+        this.samplesQcFailed = new SampleCount(0,0)
+        this.samplesLibraryPrepFinished = new SampleCount(0,0)
+        this.sampleDataAvailable = new SampleCount(0,0)
         this.totalSampleCount = 0
     }
 

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectSummary.groovy
@@ -18,7 +18,6 @@ class ProjectSummary {
     int totalSampleCount
     SampleCount samplesReceived
     SampleCount samplesQcPassed
-    SampleCount samplesQcFailed
     SampleCount samplesLibraryPrepFinished
     SampleCount sampleDataAvailable
 
@@ -27,7 +26,6 @@ class ProjectSummary {
         this.title = title
         this.samplesReceived = new SampleCount(0,0)
         this.samplesQcPassed = new SampleCount(0,0)
-        this.samplesQcFailed = new SampleCount(0,0)
         this.samplesLibraryPrepFinished = new SampleCount(0,0)
         this.sampleDataAvailable = new SampleCount(0,0)
         this.totalSampleCount = 0

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/SampleCount.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/SampleCount.groovy
@@ -1,0 +1,20 @@
+package life.qbic.portal.sampletracking.components.projectoverview
+
+import groovy.transform.EqualsAndHashCode
+
+/**
+ * <b>Stores the number of failing and passing sample counts for a status</b>
+ *
+ * @since 1.0.0
+ */
+@EqualsAndHashCode
+class SampleCount {
+
+    int passingSamples = 0
+    int failingSamples = 0
+
+    SampleCount(int passing, int failing){
+        passingSamples = passing
+        failingSamples = failing
+    }
+}

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceService.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceService.groovy
@@ -15,6 +15,7 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
 
     StatusCountResourceService() {
         this.addTopic(Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
+        this.addTopic(Topic.SAMPLE_PASSED_QC_COUNT_UPDATE)
         this.addTopic(Topic.SAMPLE_FAILED_QC_COUNT_UPDATE)
         this.addTopic(Topic.SAMPLE_DATA_AVAILABLE_COUNT_UPDATE)
         this.addTopic(Topic.SAMPLE_LIBRARY_PREP_FINISHED)
@@ -31,6 +32,10 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
         switch (statusCount.status) {
             case Status.SAMPLE_RECEIVED:
                 publish(statusCount, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
+                content.add(statusCount)
+                break
+            case Status.SAMPLE_QC_PASS:
+                publish(statusCount, Topic.SAMPLE_PASSED_QC_COUNT_UPDATE)
                 content.add(statusCount)
                 break
             case Status.SAMPLE_QC_FAIL:
@@ -62,6 +67,10 @@ class StatusCountResourceService extends ResourceService<StatusCount>{
         switch (statusCount.status) {
             case Status.SAMPLE_RECEIVED:
                 publish(statusCount, Topic.SAMPLE_RECEIVED_COUNT_UPDATE)
+                content.remove(statusCount)
+                break
+            case Status.SAMPLE_QC_PASS:
+                publish(statusCount, Topic.SAMPLE_PASSED_QC_COUNT_UPDATE)
                 content.remove(statusCount)
                 break
             case Status.SAMPLE_QC_FAIL:

--- a/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
+++ b/sample-tracking-status-overview-app/src/test/groovy/life/qbic/portal/sampletracking/resource/status/StatusCountResourceServiceSpec.groovy
@@ -16,7 +16,7 @@ class StatusCountResourceServiceSpec extends Specification {
     StatusCountResourceService statusCountService = new StatusCountResourceService()
     Subscriber<StatusCount> subscriber1 = Mock()
 
-    @Shared def knownStatuses = [Status.SAMPLE_RECEIVED, Status.SAMPLE_QC_FAIL, Status.DATA_AVAILABLE, Status.LIBRARY_PREP_FINISHED].sort { a, b -> a.name() <=> b.name()}
+    @Shared def knownStatuses = [Status.SAMPLE_RECEIVED, Status.SAMPLE_QC_PASS, Status.SAMPLE_QC_FAIL, Status.DATA_AVAILABLE, Status.LIBRARY_PREP_FINISHED].sort { a, b -> a.name() <=> b.name()}
     @Shared def unknownStatuses = Status.values().findAll {! (it in knownStatuses)}.sort {a,b -> a.name() <=> b.name()}
 
     def "Removing and adding a count for #status informs all subscribers to #topic"() {


### PR DESCRIPTION
Extends the sample count (in the view backend) so that it is able to store passing and failing counts at the same time