### PR TITLE
dm-54-implement-functionality-upon-project-selection-and-deselection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Unsubscribe from project (`#129 <https://github.com/qbicsoftware/sample-tracking-status-overview/issues/129>`_)
 
+* Samples with failed QC are shown to the user directly after selecting a project (`#138 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/138>`_)
+
 **Fixed**
 
 * Show correct number of passing QC numbers (`#130 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/130>`_)

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -87,24 +87,26 @@ class ProjectOverviewView extends VerticalLayout{
         detailsButton.setIcon(VaadinIcons.INFO_CIRCLE)
         detailsButton.setEnabled(false)
 
-        projectGrid.addSelectionListener({
-            failedQCSamplesView.setVisible(false)
-
-            if(viewModel.selectedProject && viewModel.selectedProject.samplesQc.failingSamples > 0){
+        viewModel.addPropertyChangeListener("selectedProject", {
+            if (failingSamplesExist()) {
                 detailsButton.setEnabled(true)
-            }else{
+            } else {
                 detailsButton.setEnabled(false)
             }
         })
 
         detailsButton.addClickListener({
-            if(viewModel.selectedProject){
-                projectOverviewController.getFailedQcSamples(viewModel.selectedProject.code)
-                failedQCSamplesView.setVisible(true)
-            }
+            loadFailedQcSamples(viewModel.selectedProject)
         })
 
         return detailsButton
+    }
+
+    private void loadFailedQcSamples(ProjectSummary projectSummary) {
+        Optional<ProjectSummary> selectedProject = Optional.ofNullable(projectSummary)
+        selectedProject
+                .map({it.getCode()})
+                .ifPresent(projectOverviewController::getFailedQcSamples)
     }
 
     private Button setUpLinkButton(){

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -63,9 +63,24 @@ class ProjectOverviewView extends VerticalLayout{
         titleLabel.addStyleName(ValoTheme.LABEL_LARGE)
         setupProjects()
         HorizontalLayout buttonBar = setupButtonLayout()
-        failedQCSamplesView.setVisible(false)
+        connectFailedQcSamplesView()
         bindManifestToProjectSelection()
         this.addComponents(titleLabel,buttonBar, projectGrid, failedQCSamplesView)
+    }
+
+    private void connectFailedQcSamplesView() {
+        FailedQCSamplesView samplesView = failedQCSamplesView
+        showWhenFailingSamplesExist(samplesView)
+
+        viewModel.addPropertyChangeListener("selectedProject", {
+            Optional<ProjectSummary> selectedProject = Optional.ofNullable(viewModel.selectedProject)
+            selectedProject.ifPresent({
+                loadFailedQcSamples(it)
+            })
+            if (!selectedProject.isPresent()) {
+                samplesView.reset()
+            }
+        })
     }
 
     private HorizontalLayout setupButtonLayout() {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -330,6 +330,21 @@ class ProjectOverviewView extends VerticalLayout{
         })
     }
 
+    private void showWhenFailingSamplesExist(Component component) {
+        component.setVisible(failingSamplesExist())
+        viewModel.addPropertyChangeListener("selectedProject", {
+            component.setVisible(failingSamplesExist())
+        })
+    }
+
+    private boolean failingSamplesExist() {
+        Optional<ProjectSummary> selectedProject = Optional.ofNullable(viewModel.selectedProject)
+        boolean hasFailingSamples = selectedProject
+                .map({ it.samplesQc.failingSamples > 0 })
+                .orElse(false)
+        return hasFailingSamples
+    }
+
     private void subscribeToProject(String projectCode) {
         if (viewModel.subscriber) {
             if (projectCode) {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -118,10 +118,8 @@ class ProjectOverviewView extends VerticalLayout{
     }
 
     private void loadFailedQcSamples(ProjectSummary projectSummary) {
-        Optional<ProjectSummary> selectedProject = Optional.ofNullable(projectSummary)
-        selectedProject
-                .map({it.getCode()})
-                .ifPresent(projectOverviewController::getFailedQcSamples)
+        String code = projectSummary.getCode()
+        projectOverviewController.getFailedQcSamples(code)
     }
 
     private Button setUpLinkButton(){

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -1,6 +1,5 @@
 package life.qbic.portal.sampletracking.components.projectoverview
 
-
 import com.vaadin.data.provider.DataProvider
 import com.vaadin.data.provider.ListDataProvider
 import com.vaadin.event.selection.SingleSelectionEvent
@@ -145,7 +144,7 @@ class ProjectOverviewView extends VerticalLayout{
 
         CheckBox subscriptionCheckBox = new CheckBox("Subscribe")
         subscriptionCheckBox.setVisible(false)
-        enableWhenProjectIsSelected(subscriptionCheckBox)
+        showWhenProjectIsSelected(subscriptionCheckBox)
         subscriptionCheckBox.setValue(false)
         viewModel.addPropertyChangeListener("selectedProject", {
             Optional<ProjectSummary> selectedProjectSummary = Optional.ofNullable(it.newValue as ProjectSummary)
@@ -232,8 +231,6 @@ class ProjectOverviewView extends VerticalLayout{
     private void bindManifestToProjectSelection() {
         viewModel.addPropertyChangeListener("selectedProject", { tryToDownloadManifest() })
     }
-
-
 
     private void clearProjectSelection() {
         viewModel.selectedProject = null
@@ -323,14 +320,14 @@ class ProjectOverviewView extends VerticalLayout{
         return isAvailable
     }
 
-    private void enableWhenProjectIsSelected(CheckBox checkBox) {
-        viewModel.addPropertyChangeListener("selectedProject") {
+    private void showWhenProjectIsSelected(CheckBox checkBox) {
+        viewModel.addPropertyChangeListener("selectedProject", {
             if(viewModel.selectedProject){
              checkBox.setVisible(true)
             }else{
               checkBox.setVisible(false)
             }
-        }
+        })
     }
 
     private void subscribeToProject(String projectCode) {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/samplelist/FailedQCSamplesView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/samplelist/FailedQCSamplesView.groovy
@@ -1,13 +1,11 @@
 package life.qbic.portal.sampletracking.components.projectoverview.samplelist
 
-
 import com.vaadin.data.provider.DataProvider
 import com.vaadin.ui.Grid
 import com.vaadin.ui.VerticalLayout
 import life.qbic.business.samples.info.GetSamplesInfoOutput
 import life.qbic.datamodel.samples.Status
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
-import life.qbic.portal.sampletracking.components.NotificationHandler
 
 /**
  * <b>Shows the failed QC samples </b>
@@ -31,6 +29,16 @@ class FailedQCSamplesView extends VerticalLayout {
         createSamplesGrid()
 
         this.addComponent(samplesGrid)
+    }
+
+    /**
+     * Resets the view to its initial state.
+     * @since 1.0.0
+     */
+    void reset() {
+        if (viewModel.samples.size() > 0) {
+            viewModel.samples.clear()
+        }
     }
 
     private void createSamplesGrid() {

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -37,7 +37,8 @@ class GetSamplesInfo implements GetSamplesInfoInput {
    */
   @Override
   void requestSampleInfosFor(String projectCode, Status status) {
-    //TODO make sure the project code and status are not null
+    Objects.requireNonNull(status, "Tried to request sample infos without providing a status.")
+    Objects.requireNonNull(projectCode, "Tried to request sample infos without providing a projectCode.")
     try {
         def sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode, status)
         def sampleCodesToNames = infoDataSource.fetchSampleNamesFor(sampleCodes)

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -37,6 +37,7 @@ class GetSamplesInfo implements GetSamplesInfoInput {
    */
   @Override
   void requestSampleInfosFor(String projectCode, Status status) {
+    //TODO make sure the project code and status are not null
     try {
         def sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode, status)
         def sampleCodesToNames = infoDataSource.fetchSampleNamesFor(sampleCodes)


### PR DESCRIPTION
Many thanks for contributing to this project!

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
Users do not need to click on the `Show Details` Button anymore. When selecting a project with failed QC samples, the corresponding information is shown automatically.

This solves DM-54

**Technical details**
The selection of a project summary in the view model now leads to display/hiding of the failed qc samples. In addition to that the use case `GetSamplesInfo` is triggered for the selected project summary or the current failed samples info is reset in case of an empty selection.