### PR TITLE
dm-56-add-a-hide-button-that-hides-the-failing-samples-grid

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/samplelist/FailedQCSamplesView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/samplelist/FailedQCSamplesView.groovy
@@ -1,13 +1,11 @@
 package life.qbic.portal.sampletracking.components.projectoverview.samplelist
 
-
 import com.vaadin.data.provider.DataProvider
-import com.vaadin.ui.Grid
-import com.vaadin.ui.VerticalLayout
+import com.vaadin.icons.VaadinIcons
+import com.vaadin.ui.*
 import life.qbic.business.samples.info.GetSamplesInfoOutput
 import life.qbic.datamodel.samples.Status
 import life.qbic.portal.sampletracking.communication.notification.NotificationService
-import life.qbic.portal.sampletracking.components.NotificationHandler
 
 /**
  * <b>Shows the failed QC samples </b>
@@ -19,6 +17,7 @@ class FailedQCSamplesView extends VerticalLayout {
     private final Presenter presenter
 
     private Grid<Sample> samplesGrid
+    private HorizontalLayout controls
 
     FailedQCSamplesView(NotificationService notificationService) {
         this.viewModel = new ViewModel()
@@ -28,19 +27,34 @@ class FailedQCSamplesView extends VerticalLayout {
 
     private void initLayout() {
         this.setMargin(false)
+        this.setCaption("Samples that failed quality control")
+        createControls()
         createSamplesGrid()
-
-        this.addComponent(samplesGrid)
+        this.addComponents(controls, samplesGrid)
     }
 
     private void createSamplesGrid() {
 
         this.samplesGrid = new Grid<>()
-        samplesGrid.setCaption("Samples that failed quality control")
         samplesGrid.addColumn(Sample::getCode).setCaption("Sample Code").setId("SampleCode")
         samplesGrid.addColumn(Sample::getTitle).setCaption("Sample Title").setId("SampleTitle")
         samplesGrid.setSelectionMode(Grid.SelectionMode.NONE)
         samplesGrid.setDataProvider(DataProvider.ofCollection(viewModel.getSamples()))
+    }
+
+    private void createControls() {
+        controls = new HorizontalLayout()
+        Button closeButton = setupCloseButton()
+        this.controls.addComponent(closeButton)
+        this.controls.setComponentAlignment(closeButton, Alignment.TOP_LEFT)
+    }
+
+    private Button setupCloseButton() {
+        Button closeButton = new Button("Hide", VaadinIcons.CLOSE)
+        closeButton.addClickListener({
+            this.setVisible(false)
+        })
+        return closeButton
     }
 
     GetSamplesInfoOutput getPresenter() {


### PR DESCRIPTION
Addresses DM-56

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked

**Description of changes**
Adds a "Hide" button to the samples list that failed QC.

