### PR TITLE
Fix/dm 129 double click project error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Address error when double-clicking a project with no samples (`#164 <https://github.com/qbicsoftware/sample-tracking-status-overview/pull/164>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -250,8 +250,13 @@ class ProjectOverviewView extends VerticalLayout implements HasHotbar, HasTitle 
             return "clickable-row"
         })
         viewModel.updatedProjectsChannel.subscribe({updatedProjectCode ->
-            refreshDataProvider()
+            filterEmptyProjects()
         })
+    }
+
+    private void filterEmptyProjects(){
+        ListDataProvider<ProjectSummary> dataProvider = (ListDataProvider<ProjectSummary>) projectGrid.getDataProvider()
+        dataProvider.setFilter(ProjectSummary::getTotalSampleCount, totalNumber -> totalNumber > 0)
     }
 
     private void selectProject(ProjectSummary projectSummary) {
@@ -333,10 +338,13 @@ class ProjectOverviewView extends VerticalLayout implements HasHotbar, HasTitle 
     private void refreshDataProvider() {
         DataProvider dataProvider = new ListDataProvider(viewModel.projectOverviews)
         projectGrid.setDataProvider(dataProvider)
+
         if( viewModel.selectedProject ) {
             projectGrid.select(viewModel.selectedProject)
         }
         GridUtils.setupFilters(projectGrid, columnIdsWithFilters)
+
+        filterEmptyProjects()
     }
 
     private void tryToDownloadManifest() {

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectOverviewView.groovy
@@ -250,7 +250,7 @@ class ProjectOverviewView extends VerticalLayout implements HasHotbar, HasTitle 
             return "clickable-row"
         })
         viewModel.updatedProjectsChannel.subscribe({updatedProjectCode ->
-            filterEmptyProjects()
+            refreshDataProvider()
         })
     }
 

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -99,7 +99,7 @@ class GetSamplesInfo implements GetSamplesInfoInput {
   private static Set<Map.Entry<String, String>> getCommonEntrySet(Map<String, String> codesToNames, Map<String, Status> codesToStatus) {
     Set codeNameKeys = codesToNames.keySet()
     Set codeStatusKeys = codesToStatus.keySet()
-    if (codeNameKeys != codeStatusKeys) {
+    if (!codeNameKeys.containsAll(codeStatusKeys)) {
       Set<Map.Entry<String, String>> commonEntries = codesToNames.entrySet().stream().filter(entry -> codeStatusKeys.contains(entry.key)).collect(Collectors.toSet())
       return commonEntries
     }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -62,12 +62,16 @@ class GetSamplesInfo implements GetSamplesInfoInput {
   void requestSampleInfosFor(String projectCode) {
     Objects.requireNonNull(projectCode, "Tried to request sample infos without providing a projectCode.")
     try {
-      def sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode)
+      List<String> sampleCodes = samplesDataSource.fetchSampleCodesFor(projectCode)
+      if (sampleCodes.isEmpty()) {
+        //ToDo should this be notified to the user?
+        output.samplesWithNames([])
+        return
+      }
       def sampleCodesToNames = infoDataSource.fetchSampleNamesFor(sampleCodes)
       def sampleCodesToStatus = statusDataSource.fetchSampleStatusesFor(sampleCodes)
       List<Sample> samplesWithNames = buildSamples(sampleCodesToNames, sampleCodesToStatus)
       output.samplesWithNames(samplesWithNames)
-
     } catch (DataSourceException dataSourceException) {
       output.failedExecution(dataSourceException.getMessage())
     }

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -100,7 +100,7 @@ class GetSamplesInfo implements GetSamplesInfoInput {
     Set codeNameKeys = codesToNames.keySet()
     Set codeStatusKeys = codesToStatus.keySet()
     if (codeNameKeys != codeStatusKeys) {
-      Set<Map.Entry<String, String>> commonEntries = codesToNames.entrySet().stream().filter(i -> codeStatusKeys.contains(i.key)).collect(Collectors.toSet())
+      Set<Map.Entry<String, String>> commonEntries = codesToNames.entrySet().stream().filter(entry -> codeStatusKeys.contains(entry.key)).collect(Collectors.toSet())
       return commonEntries
     }
     return codesToNames.entrySet()

--- a/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
+++ b/sample-tracking-status-overview-domain/src/main/groovy/life/qbic/business/samples/info/GetSamplesInfo.groovy
@@ -96,10 +96,16 @@ class GetSamplesInfo implements GetSamplesInfoInput {
     return Optional.ofNullable(samples).orElse([])
   }
 
+  /**
+   * Compares the sampleCode mappings retrieved from openBis with the mappings retrieved from the database and returns the common sampleCode subset
+   * @param codesToNames contains a mapping of the sample description to the sample code
+   * @param codesToString contains a mapping of the sample status to the sample code
+   * @since 1.0.0
+   */
   private static Set<Map.Entry<String, String>> getCommonEntrySet(Map<String, String> codesToNames, Map<String, Status> codesToStatus) {
     Set codeNameKeys = codesToNames.keySet()
     Set codeStatusKeys = codesToStatus.keySet()
-    if (!codeNameKeys.containsAll(codeStatusKeys)) {
+    if (codeNameKeys != codeStatusKeys) {
       Set<Map.Entry<String, String>> commonEntries = codesToNames.entrySet().stream().filter(entry -> codeStatusKeys.contains(entry.key)).collect(Collectors.toSet())
       return commonEntries
     }


### PR DESCRIPTION
**Description of changes**
Addresses [DM-129](https://qbicsoftware.atlassian.net/jira/software/c/projects/DM/boards/4?modal=detail&selectedIssue=DM-129) by introducing checks for the following cases: 

1.) No sampleCodes could be retrieved from the database for a provided projectCode. 
For this a dedicated check of the `sampleCodes` List is introduced that will lead the Use Case to return an empty list if the `samplesDataSource.fetchSampleCodesFor` method returns no sampleCodes. 
(This also avoids the specific case of putting an empty list to the `statusDataSource.fetchSampleStatusesFor` method, which will return a map of ALL samplecodes with their respective statuses since the searchCriteria was not specified) 

2.) The **samplecodes mapped to their description** (retrieved from the database) differ from the **samplecodes mapped to their status** (retrieved from openBis). 
The introduced `getCommonEntrySet` will determine a common subset, from which the samples will be built.

**How To Test** 
Check ProjectCode _**QBWPB**_ to test for case 2.) (different sampleCodes in openBis and the database)
Check ProjectCode **_Q0009_** or **_QB030_** for case 1.) (no SampleCodes could be found in the database for the provided projectCode) 