### PR TITLE
Revert Release/1.1.0 to Master 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,21 +4,6 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.1.0 (2022-01-31)
----------------------------
-
-**Added**
-
-**Fixed**
-
-* Fix wording in sorting to improve UX (#213)
-
-* Search field not working after subscription change (#212)
-
-**Dependencies**
-
-**Deprecated**
-
 1.0.0 (2022-01-31)
 ---------------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </modules>
   <artifactId>sample-tracking-status-overview</artifactId>
   <groupId>life.qbic</groupId>
-  <version>1.1.0</version> <!-- <<QUBE_FORCE_BUMP>> -->
+  <version>1.0.0</version> <!-- <<QUBE_FORCE_BUMP>> -->
   <name>Sample Tracking Status Overview</name>
   <url>https://github.com/qbicsoftware/sample-tracking-status-overview</url>
   <description>Gives a visual overview of sample statuses</description>

--- a/sample-tracking-status-overview-app/pom.xml
+++ b/sample-tracking-status-overview-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sample-tracking-status-overview</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.1.0</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectView.groovy
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/components/projectoverview/ProjectView.groovy
@@ -116,7 +116,7 @@ class ProjectView extends ProjectDesign {
     }
 
     private void addSorting(){
-        sort.setItems(["Newest Changes", "Oldest Changes", "Subscribed", "Not Subscribed"])
+        sort.setItems(["Recently Updated", "Last Recently Updated", "Subscribed", "Not Subscribed"])
 
         sort.addValueChangeListener({
             if(it.value){
@@ -127,10 +127,10 @@ class ProjectView extends ProjectDesign {
                     case "Not Subscribed":
                         projectGrid.sort("Subscription", SortDirection.ASCENDING)
                         break
-                    case "Newest Changes":
+                    case "Recently Updated":
                         projectGrid.sort("lastUpdated", SortDirection.DESCENDING)
                         break
-                    case "Oldest Changes":
+                    case "Last Recently Updated":
                         projectGrid.sort("lastUpdated", SortDirection.ASCENDING)
                         break
                     default:
@@ -280,18 +280,14 @@ class ProjectView extends ProjectDesign {
 
     void enableUserProjectFiltering() {
         TextField searchField = this.searchField
+        DataProvider<ProjectSummary, ?> dataProvider = this.projectGrid.getDataProvider()
         searchField.addValueChangeListener({
             if (it.getValue()) {
                 projectFilter.containingText(it.getValue())
             } else {
                 projectFilter.containingText("")
             }
-            currentDataProvider().refreshAll()
+            dataProvider.refreshAll()
         })
-    }
-
-    private DataProvider<ProjectSummary, ?> currentDataProvider() {
-        DataProvider<ProjectSummary, ?> dataProvider = this.projectGrid.getDataProvider()
-        return dataProvider
     }
 }

--- a/sample-tracking-status-overview-domain/pom.xml
+++ b/sample-tracking-status-overview-domain/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>sample-tracking-status-overview</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.1.0</version>
+        <version>1.0.0</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Reverts 1.1.0 Release commit to master branch since it's not a feature but a hotfix. 
The actual release PR for 1.0.1 can be found here: #215 

In detail This PR reverts commit 48723e92cb512981199ace3dcd4cac8005d865d0, reversing
changes made to f8133eb1bf4d242ebcc81d1280a381634ff4a6ba.

