### PR TITLE
Renam Github workflow job names

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -3,7 +3,7 @@ name: Build Maven Package
 on: [push]
 
 jobs:
-  build:
+  package:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, edited ]
 
 jobs:
-  build:
+  label:
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v3

--- a/.github/workflows/nexus-publish-snapshots.yml
+++ b/.github/workflows/nexus-publish-snapshots.yml
@@ -10,7 +10,7 @@ on:
       - development
 
 jobs:
-  build:
+  publish_snapshot:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,7 +3,7 @@ name: Run Maven Tests
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR provides declarative names for the workflow jobs, so we can use them for branch protection rules.