### PR TITLE
Fix projectgrid window size on big screens

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/view/projects/ProjectView.java
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/view/projects/ProjectView.java
@@ -259,6 +259,7 @@ public class ProjectView extends ProjectDesign {
         .setId("title")
         .setExpandRatio(1)
         .setStyleGenerator(it -> "title-cell")
+        .setMinimumWidthFromContent(false)
         .setDescriptionGenerator(Project::title)
         .setResizable(false)
         .setSortable(false);

--- a/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/sample-tracking-status-overview-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -92,7 +92,6 @@
 
   .title-cell {
     min-width: 100px;
-    max-width: 40%;
   }
 
   .code-cell {
@@ -127,7 +126,7 @@
 
   /* projectGrid layout can't be smaller otherwise the download button and project/sample button will overlap*/
   .responsive-grid-layout {
-    min-width: 1000px;
+    min-width: 1200px;
     display: block;
   }
 }


### PR DESCRIPTION
**What was changed** 
This PR removes the set max width of the project title column since it leads to empty column space inside the grid on bigger screens (can be seen on qPortal and is highlighted in red). 
![Bildschirmfoto 2022-09-21 um 17 02 18](https://user-images.githubusercontent.com/29627977/191540470-27769c85-7afc-4993-8bbf-4cc01a48f794.png)

**How to test** 
Check out branch and adapt screen size to different settings. 
The grid will be rendered correctly(no empty space inside the grid) independent of the green size. 