### PR TITLE
Add missing NGS types

### DIFF
--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/data/OpenBisConnector.java
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/data/OpenBisConnector.java
@@ -75,6 +75,11 @@ public class OpenBisConnector implements ProjectRepository, SampleRepository, Ng
     isNgs.withOrOperator();
     isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("DNA");
     isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("RNA");
+    isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("AMPLICON");
+    isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("R_RNA");
+    isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("M_RNA");
+    isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("SINGLE_NUCLEI");
+    isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("CF_DNA");
     // this guarantees that no q-entity is contained as only test samples have Q_SAMPLE_TYPE
 
     SampleFetchOptions fetchOptions = new SampleFetchOptions();

--- a/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/data/OpenBisConnector.java
+++ b/sample-tracking-status-overview-app/src/main/groovy/life/qbic/portal/sampletracking/data/OpenBisConnector.java
@@ -73,6 +73,7 @@ public class OpenBisConnector implements ProjectRepository, SampleRepository, Ng
 
     SampleSearchCriteria isNgs = new SampleSearchCriteria();
     isNgs.withOrOperator();
+    //search for all sample types that are related to NGS
     isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("DNA");
     isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("RNA");
     isNgs.withProperty("Q_SAMPLE_TYPE").thatContains("AMPLICON");


### PR DESCRIPTION
Hotfix as project QLVFH was not found --> sample type was Single Nuclei

We filtered for only RNA and DNA sample since we were not sure if other data types were needed. It turns out they matter. I added also other data types related to NGS sample types.